### PR TITLE
[#6] Splash 화면 UI 개발

### DIFF
--- a/lib/app/cherrypic_app.dart
+++ b/lib/app/cherrypic_app.dart
@@ -4,6 +4,8 @@ import 'package:cherrypic/presentation/screens/test/album_card_test_screen.dart'
 import 'package:cherrypic/presentation/screens/test/labeled_text_field_test_screen.dart';
 import 'package:cherrypic/core/constants/font.dart';
 
+import '../presentation/screens/login/splash_screen.dart';
+
 class CherrypicApp extends StatelessWidget {
   const CherrypicApp({super.key});
 
@@ -16,7 +18,8 @@ class CherrypicApp extends StatelessWidget {
         scaffoldBackgroundColor: Colors.white,
         useMaterial3: true,
       ),
-      home: const LabeledTextFieldTestScreen(),
+      // home: const LabeledTextFieldTestScreen(),
+      home: const SplashScreen(),
     );
   }
 }

--- a/lib/core/constants/color.dart
+++ b/lib/core/constants/color.dart
@@ -8,4 +8,5 @@ class AppColor {
   static const Color subGrey = Color(0xFF4D4D4D);
   static const Color subSlicer = Color(0xFFE4E4E4);
   static const Color highlightBlue = Color(0xFF0073FF);
+  static const Color mainPink = Color(0xFFFACCCF);
 }

--- a/lib/presentation/screens/login/splash_screen.dart
+++ b/lib/presentation/screens/login/splash_screen.dart
@@ -1,0 +1,68 @@
+import 'package:cherrypic/core/constants/color.dart';
+import 'package:cherrypic/presentation/screens/login/login_screen.dart';
+import 'package:cherrypic/presentation/screens/main/main_screen.dart';
+import 'package:flutter/material.dart';
+
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(
+      const Duration(seconds: 3), () async {
+        final hasHistory = await hasSocialLoginHistory();
+        Navigator.pushReplacement(
+          context,
+          PageRouteBuilder(
+            pageBuilder: (_, __, ___) => hasHistory ? const MainScreen() : const LoginScreen(),
+            transitionDuration: Duration.zero,
+            reverseTransitionDuration: Duration.zero,
+          ),
+        );
+      },
+    );
+  }
+
+  // 소셜 로그인 기록 여부
+  Future<bool> hasSocialLoginHistory() async {
+    return Future.value(false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Container(
+          decoration: BoxDecoration(
+            color: AppColor.mainPink,
+          ),
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Image.asset(
+                  'assets/images/CherryPic_logo.png',
+                  width: 130,
+                  height: 198,
+                ),
+                const SizedBox(height: 20),
+                Image.asset(
+                  'assets/images/CherryPic_title.png',
+                  width: 223,
+                  height: 71,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Splash 화면 제작

#6

### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #이슈번호

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Splash 화면 UI를 제작했습니다.
- 우선은, 소셜로그인 이력 여부에 대해 bool값을 통해 true이면 main_screen으로 분기, false이면 login_screen으로 분기하도록 설정했습니다.
<img width="250" height = "500"  src="https://github.com/user-attachments/assets/b31ca3de-2a7a-4992-be80-9fe7022d22ec" />

<img width="250" height = "500"  src="https://github.com/user-attachments/assets/4773ac45-0da5-4f95-80b9-5e02d3d451df" />

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- Splash 화면 지속 시간 몇초를 해야할지 물어봐야겠습니다
