### PR TITLE
[#23] 앨범 설정 화면 & alert 모달 구현

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -84,7 +84,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
 SPEC CHECKSUMS:
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
   flutter_web_auth_2: 5c8d9dcd7848b5a9efb086d24e7a9adcae979c80
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -2,6 +2,7 @@ import 'package:cherrypic/core/router/route_path.dart';
 import 'package:cherrypic/presentation/screens/event/event_list_detail/event_list_screen.dart';
 import 'package:cherrypic/presentation/screens/event/event_main_screen.dart';
 import 'package:cherrypic/presentation/screens/main/album/add/album_add_screen.dart';
+import 'package:cherrypic/presentation/screens/main/album/edit/album_edit_screen.dart';
 import 'package:cherrypic/presentation/screens/main/detail/album_detail_screen.dart';
 import 'package:cherrypic/presentation/screens/main/home_tab/main_screen.dart';
 import 'package:cherrypic/presentation/screens/my_page/address_management/add_address_screen.dart';
@@ -48,6 +49,15 @@ final Map<String, GoRouterWidgetBuilder> routeBuilders = {
     return AlbumDetailScreen(albumId: albumId);
   },
 
+  RoutePath.albumSetting: (context, state) {
+    final idStr =
+        state.pathParameters['albumId'] ??
+        state.uri.queryParameters['albumId'] ??
+        '-1';
+    final albumId = int.tryParse(idStr) ?? -1;
+    return AlbumEditScreen(albumId: albumId);
+  },
+
   /// myPage
   RoutePath.myPage: (context, state) => const MyPageScreen(),
   RoutePath.myPage_notice: (context, state) => const NoticeScreen(),
@@ -77,7 +87,7 @@ final Map<String, GoRouterWidgetBuilder> routeBuilders = {
   RoutePath.store_subs_info: (context, state) {
     final typeParam = state.uri.queryParameters['type'];
     final storeType = StoreType.values.firstWhere(
-          (e) => e.name == typeParam,
+      (e) => e.name == typeParam,
       orElse: () => StoreType.basic,
     );
     return StoreSubsInfo(storeType: storeType);

--- a/lib/core/router/route_path.dart
+++ b/lib/core/router/route_path.dart
@@ -1,6 +1,7 @@
 class RoutePath {
   static const String home = '/';
   static const String albumAdd = '/album/add';
+  static const String albumSetting = '/album/:albumId/setting';
 
   static const String myPage = '/my_page/my_page_screen';
   static const String myPage_notice = '/my_page/notice/notice_screen';

--- a/lib/presentation/screens/main/album/add/album_add_screen.dart
+++ b/lib/presentation/screens/main/album/add/album_add_screen.dart
@@ -1,7 +1,9 @@
+import 'package:cherrypic/presentation/screens/main/album/add/album_add_view_model.dart'; // 새로 만든 ViewModel 임포트
 import 'package:cherrypic/presentation/screens/main/album/components/album_cover_section.dart';
-import 'package:cherrypic/presentation/screens/main/album/components/album_cover_view_model.dart'; // ViewModel 임포트
+import 'package:cherrypic/presentation/screens/main/album/components/album_cover_view_model.dart';
 import 'package:cherrypic/presentation/screens/main/album/components/album_permission_toggle.dart';
 import 'package:cherrypic/presentation/screens/main/album/components/album_type_selector.dart';
+import 'package:cherrypic/presentation/widgets/custom_button.dart';
 import 'package:flutter/material.dart';
 import 'package:cherrypic/core/constants/font.dart';
 import 'package:go_router/go_router.dart';
@@ -15,54 +17,78 @@ class AlbumAddScreen extends StatefulWidget {
 
 class _AlbumAddScreenState extends State<AlbumAddScreen> {
   late final AlbumCoverViewModel _albumCoverViewModel;
+  late final AlbumAddViewModel _albumAddViewModel; // AlbumAddViewModel 추가
 
   @override
   void initState() {
     super.initState();
     _albumCoverViewModel = AlbumCoverViewModel();
+    _albumAddViewModel = AlbumAddViewModel(); // ViewModel 초기화
   }
 
   @override
   void dispose() {
     _albumCoverViewModel.dispose();
+    _albumAddViewModel.dispose(); // ViewModel dispose
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Colors.white,
-        elevation: 0,
-        centerTitle: true,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: Colors.black),
-          onPressed: () => context.pop(),
-        ),
-        title: Text(
-          '앨범 추가',
-          style: AppFont.size20.copyWith(
-            color: Colors.black,
-            fontWeight: FontWeight.w800,
+    // 두 개의 ViewModel 변경을 모두 감지하도록 Listenable.merge 사용
+    return AnimatedBuilder(
+      animation: Listenable.merge([_albumCoverViewModel, _albumAddViewModel]),
+      builder: (context, child) {
+        return Scaffold(
+          appBar: AppBar(
+            backgroundColor: Colors.white,
+            elevation: 0,
+            centerTitle: true,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back, color: Colors.black),
+              onPressed: () => context.pop(),
+            ),
+            title: Text(
+              '앨범 추가',
+              style: AppFont.size20.copyWith(
+                color: Colors.black,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
           ),
-        ),
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              AlbumCoverSection(viewModel: _albumCoverViewModel),
-              const SizedBox(height: 80),
-              const AlbumTypeSelector(),
-              const SizedBox(height: 50),
-              const AlbumPermissionToggle(showLockSetting: false),
-              const SizedBox(height: 50),
-            ],
+          body: SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 30),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  AlbumCoverSection(viewModel: _albumCoverViewModel),
+                  const SizedBox(height: 80),
+                  const AlbumTypeSelector(),
+                  const SizedBox(height: 50),
+
+                  // [수정] AlbumPermissionToggle 호출 방식 변경
+                  AlbumPermissionToggle(
+                    isPermissionEnabled: _albumAddViewModel.isPermissionEnabled,
+                    onPermissionToggled: _albumAddViewModel.togglePermission,
+                    showMemberList: false, // 멤버 리스트를 보여주지 않음
+                    // 멤버 관련 파라미터는 전달할 필요 없음
+                  ),
+                  const SizedBox(height: 40),
+
+                  // 앨범 생성 버튼
+                  CustomButton(
+                    text: '앨범 생성',
+                    onPressed: () {
+                      // TODO: 앨범 생성 로직 구현
+                    },
+                  ),
+                ],
+              ),
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/presentation/screens/main/album/add/album_add_screen.dart
+++ b/lib/presentation/screens/main/album/add/album_add_screen.dart
@@ -17,25 +17,24 @@ class AlbumAddScreen extends StatefulWidget {
 
 class _AlbumAddScreenState extends State<AlbumAddScreen> {
   late final AlbumCoverViewModel _albumCoverViewModel;
-  late final AlbumAddViewModel _albumAddViewModel; // AlbumAddViewModel 추가
+  late final AlbumAddViewModel _albumAddViewModel;
 
   @override
   void initState() {
     super.initState();
     _albumCoverViewModel = AlbumCoverViewModel();
-    _albumAddViewModel = AlbumAddViewModel(); // ViewModel 초기화
+    _albumAddViewModel = AlbumAddViewModel();
   }
 
   @override
   void dispose() {
     _albumCoverViewModel.dispose();
-    _albumAddViewModel.dispose(); // ViewModel dispose
+    _albumAddViewModel.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    // 두 개의 ViewModel 변경을 모두 감지하도록 Listenable.merge 사용
     return AnimatedBuilder(
       animation: Listenable.merge([_albumCoverViewModel, _albumAddViewModel]),
       builder: (context, child) {
@@ -67,12 +66,10 @@ class _AlbumAddScreenState extends State<AlbumAddScreen> {
                   const AlbumTypeSelector(),
                   const SizedBox(height: 50),
 
-                  // [수정] AlbumPermissionToggle 호출 방식 변경
                   AlbumPermissionToggle(
                     isPermissionEnabled: _albumAddViewModel.isPermissionEnabled,
                     onPermissionToggled: _albumAddViewModel.togglePermission,
-                    showMemberList: false, // 멤버 리스트를 보여주지 않음
-                    // 멤버 관련 파라미터는 전달할 필요 없음
+                    showMemberList: false,
                   ),
                   const SizedBox(height: 40),
 

--- a/lib/presentation/screens/main/album/add/album_add_view_model.dart
+++ b/lib/presentation/screens/main/album/add/album_add_view_model.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class AlbumAddViewModel extends ChangeNotifier {
+  bool _isPermissionEnabled = false;
+  bool get isPermissionEnabled => _isPermissionEnabled;
+
+  void togglePermission(bool value) {
+    _isPermissionEnabled = value;
+    notifyListeners();
+  }
+}

--- a/lib/presentation/screens/main/album/components/album_cover_section.dart
+++ b/lib/presentation/screens/main/album/components/album_cover_section.dart
@@ -19,7 +19,7 @@ class _AlbumCoverSectionState extends State<AlbumCoverSection> {
   @override
   void initState() {
     super.initState();
-    _textController = TextEditingController();
+    _textController = TextEditingController(text: widget.viewModel.albumName);
     _textController.addListener(() {
       widget.viewModel.updateAlbumName(_textController.text);
     });
@@ -39,6 +39,7 @@ class _AlbumCoverSectionState extends State<AlbumCoverSection> {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
+            // 앨범 커버 미리보기
             // 앨범 커버 미리보기
             Container(
               width: 210,
@@ -61,24 +62,59 @@ class _AlbumCoverSectionState extends State<AlbumCoverSection> {
                     width: 210,
                     height: 224,
                     decoration: const BoxDecoration(
-                      color: Colors.grey,
+                      // 배경색은 이미지가 없을 때만 보이도록 ClipRRect 안으로 이동
                       borderRadius: BorderRadius.vertical(
                         top: Radius.circular(12),
                       ),
                     ),
-                    child: widget.viewModel.coverImage != null
-                        ? ClipRRect(
-                            borderRadius: const BorderRadius.vertical(
-                              top: Radius.circular(12),
-                            ),
-                            child: Image.memory(
+                    child: ClipRRect(
+                      borderRadius: const BorderRadius.vertical(
+                        top: Radius.circular(12),
+                      ),
+                      child: widget.viewModel.coverImage != null
+                          // 1. 새로 선택한 이미지가 있을 경우 (Uint8List)
+                          ? Image.memory(
                               widget.viewModel.coverImage!,
                               fit: BoxFit.cover,
+                              width: double.infinity,
+                            )
+                          // 2. 기존 네트워크 이미지가 있을 경우 (String URL)
+                          : (widget.viewModel.coverImageUrl != null &&
+                                widget.viewModel.coverImageUrl!.isNotEmpty)
+                          ? Image.network(
+                              widget.viewModel.coverImageUrl!,
+                              fit: BoxFit.cover,
+                              width: double.infinity,
+                              loadingBuilder:
+                                  (context, child, loadingProgress) {
+                                    if (loadingProgress == null) return child;
+                                    return const Center(
+                                      child: CircularProgressIndicator(),
+                                    );
+                                  },
+                              errorBuilder: (context, error, stackTrace) {
+                                return Container(
+                                  color: Colors.grey.shade200,
+                                  child: const Center(
+                                    child: Icon(
+                                      Icons.error_outline,
+                                      color: Colors.grey,
+                                    ),
+                                  ),
+                                );
+                              },
+                            )
+                          // 3. 표시할 이미지가 아무것도 없을 경우
+                          : Container(
+                              color: Colors.grey.shade200,
+                              child: const Center(
+                                child: Text(
+                                  '앨범 커버가 표시됩니다',
+                                  style: AppFont.size14,
+                                ),
+                              ),
                             ),
-                          )
-                        : const Center(
-                            child: Text('앨범 커버가 표시됩니다', style: AppFont.size14),
-                          ),
+                    ),
                   ),
                   Container(
                     width: 210,

--- a/lib/presentation/screens/main/album/components/album_cover_view_model.dart
+++ b/lib/presentation/screens/main/album/components/album_cover_view_model.dart
@@ -4,12 +4,14 @@ import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 
 class AlbumCoverViewModel extends ChangeNotifier {
   Uint8List? _coverImage; // 선택된 이미지 데이터 (메모리에 보관)
+  String? _coverImageUrl;
   String _albumName = '앨범 이름이 표시됩니다'; // 앨범 이름 초기값
   bool _isDefaultSelected = true; // '기존 이미지' vs '사진 업로드' 버튼 상태
   static const int maxAlbumNameLength = 20;
 
   // View에서 데이터를 사용할 수 있도록 Getter 제공
   Uint8List? get coverImage => _coverImage;
+  String? get coverImageUrl => _coverImageUrl;
   String get albumName => _albumName;
   bool get isDefaultSelected => _isDefaultSelected;
 
@@ -21,6 +23,13 @@ class AlbumCoverViewModel extends ChangeNotifier {
     if (isDefault) {
       _coverImage = null;
     }
+    notifyListeners();
+  }
+
+  // 네트워크 이미지 URL을 설정하는 메소드 추가
+  void setCoverImageUrl(String url) {
+    _coverImageUrl = url;
+    _coverImage = null; // 새로 업로드한 이미지가 있다면 초기화
     notifyListeners();
   }
 

--- a/lib/presentation/screens/main/album/components/album_permission_toggle.dart
+++ b/lib/presentation/screens/main/album/components/album_permission_toggle.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:cherrypic/core/constants/font.dart';
 import 'package:cherrypic/core/constants/color.dart';
 import 'package:cherrypic/presentation/screens/main/album/edit/album_edit_view_model.dart';
+// 새로 만든 다이얼로그 import
+import 'package:cherrypic/presentation/widgets/dialogs/custom_confirm_dialog.dart';
 
 class AlbumPermissionToggle extends StatelessWidget {
   final bool isPermissionEnabled;
@@ -26,6 +28,26 @@ class AlbumPermissionToggle extends StatelessWidget {
     this.onKickMember,
   });
 
+  // --- 멤버 내보내기 확인 다이얼로그를 표시하는 함수 ---
+  void _showKickConfirmDialog(BuildContext context, Member member) {
+    showDialog(
+      context: context,
+      builder: (BuildContext dialogContext) {
+        return CustomConfirmDialog(
+          title: '내보내기',
+          content: '${member.name} 님을 앨범에서 내보내시겠습니까?',
+          confirmButtonText: '내보내기',
+          cancelButtonText: '취소',
+          onConfirm: () {
+            if (onKickMember != null) {
+              onKickMember!(member);
+            }
+          },
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -34,7 +56,7 @@ class AlbumPermissionToggle extends StatelessWidget {
         _buildHeader(),
         if (isPermissionEnabled && showMemberList) ...[
           const SizedBox(height: 20),
-          _buildMemberListBox(),
+          _buildMemberListBox(context), // context 전달
         ],
       ],
     );
@@ -63,7 +85,8 @@ class AlbumPermissionToggle extends StatelessWidget {
     );
   }
 
-  Widget _buildMemberListBox() {
+  Widget _buildMemberListBox(BuildContext context) {
+    // context 받도록 수정
     return Container(
       height: 350,
       padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 15),
@@ -97,7 +120,7 @@ class AlbumPermissionToggle extends StatelessWidget {
             child: ListView.separated(
               itemCount: members!.length,
               itemBuilder: (context, index) =>
-                  _buildMemberListItem(members![index]),
+                  _buildMemberListItem(context, members![index]), // context 전달
               separatorBuilder: (context, index) => const SizedBox(height: 15),
             ),
           ),
@@ -106,7 +129,8 @@ class AlbumPermissionToggle extends StatelessWidget {
     );
   }
 
-  Widget _buildMemberListItem(Member member) {
+  Widget _buildMemberListItem(BuildContext context, Member member) {
+    // context 받도록 수정
     const roles = ['방장', '일반회원', '읽기 전용'];
     return SizedBox(
       height: 45,
@@ -120,7 +144,8 @@ class AlbumPermissionToggle extends StatelessWidget {
           Text(member.name, style: AppFont.size16),
           const Spacer(),
           TextButton(
-            onPressed: () => onKickMember!(member),
+            onPressed: () =>
+                _showKickConfirmDialog(context, member), // 다이얼로그 호출
             child: Text(
               '내보내기',
               style: AppFont.size14.copyWith(

--- a/lib/presentation/screens/main/album/components/album_permission_toggle.dart
+++ b/lib/presentation/screens/main/album/components/album_permission_toggle.dart
@@ -117,9 +117,11 @@ class AlbumPermissionToggle extends StatelessWidget {
           const SizedBox(height: 20),
           Expanded(
             child: ListView.separated(
-              itemCount: members!.length,
-              itemBuilder: (context, index) =>
-                  _buildMemberListItem(context, members![index]), // context 전달
+              itemCount: members?.length ?? 0,
+              itemBuilder: (context, index) => _buildMemberListItem(
+                context,
+                (members ?? [])[index],
+              ), // context 전달
               separatorBuilder: (context, index) => const SizedBox(height: 15),
             ),
           ),

--- a/lib/presentation/screens/main/album/components/album_permission_toggle.dart
+++ b/lib/presentation/screens/main/album/components/album_permission_toggle.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:cherrypic/core/constants/font.dart';
 import 'package:cherrypic/core/constants/color.dart';
 import 'package:cherrypic/presentation/screens/main/album/edit/album_edit_view_model.dart';
-// 새로 만든 다이얼로그 import
 import 'package:cherrypic/presentation/widgets/dialogs/custom_confirm_dialog.dart';
 
 class AlbumPermissionToggle extends StatelessWidget {

--- a/lib/presentation/screens/main/album/components/album_permission_toggle.dart
+++ b/lib/presentation/screens/main/album/components/album_permission_toggle.dart
@@ -1,185 +1,149 @@
-import 'package:cherrypic/presentation/widgets/text/custom_labeled_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:cherrypic/core/constants/font.dart';
 import 'package:cherrypic/core/constants/color.dart';
-import 'package:cherrypic/presentation/widgets/custom_button.dart';
+import 'package:cherrypic/presentation/screens/main/album/edit/album_edit_view_model.dart';
 
-class AlbumPermissionToggle extends StatefulWidget {
-  final bool showLockSetting;
+class AlbumPermissionToggle extends StatelessWidget {
+  final bool isPermissionEnabled;
+  final ValueChanged<bool> onPermissionToggled;
+  final bool showMemberList;
 
-  const AlbumPermissionToggle({super.key, required this.showLockSetting});
+  // --- 멤버 리스트 관련 파라미터 (선택적) ---
+  final List<Member>? members;
+  final TextEditingController? searchController;
+  final Function(Member, String)? onUpdateRole;
+  final Function(Member)? onKickMember;
 
-  @override
-  State<AlbumPermissionToggle> createState() => _AlbumPermissionToggleState();
-}
-
-class _AlbumPermissionToggleState extends State<AlbumPermissionToggle> {
-  bool isOn = false;
-  bool _showTooltip = false;
-  final GlobalKey _iconKey = GlobalKey();
-  double _tooltipLeft = 0;
-  final double _arrowOffset = 140; // 툴팁 너비 / 2 (툴팁 width = 280 기준)
-
-  void _toggleTooltip() {
-    final RenderBox renderBox =
-        _iconKey.currentContext!.findRenderObject() as RenderBox;
-    final position = renderBox.localToGlobal(Offset.zero);
-    final size = renderBox.size;
-
-    setState(() {
-      _tooltipLeft = position.dx + size.width / 2 - _arrowOffset;
-      _showTooltip = true;
-    });
-
-    Future.delayed(const Duration(seconds: 3), () {
-      if (mounted) {
-        setState(() {
-          _showTooltip = false;
-        });
-      }
-    });
-  }
+  const AlbumPermissionToggle({
+    super.key,
+    required this.isPermissionEnabled,
+    required this.onPermissionToggled,
+    this.showMemberList = false, // 기본값 false
+    // 멤버 리스트를 보여줄 때만 필요한 파라미터들
+    this.members,
+    this.searchController,
+    this.onUpdateRole,
+    this.onKickMember,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      clipBehavior: Clip.none,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // 권한 부여 + 툴팁 아이콘 + 스위치
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Row(
-                  children: [
-                    Text(
-                      '멤버별 권한 부여',
-                      style: AppFont.size18.copyWith(
-                        fontWeight: FontWeight.w700,
-                        color: Colors.black,
-                      ),
-                    ),
-                    const SizedBox(width: 4),
-                    GestureDetector(
-                      onTap: _toggleTooltip,
-                      child: Icon(
-                        Icons.info_outline,
-                        key: _iconKey,
-                        size: 18,
-                        color: AppColor.mainRed,
-                      ),
-                    ),
-                  ],
-                ),
-                Switch(
-                  value: isOn,
-                  activeColor: AppColor.mainRed,
-                  onChanged: (value) {
-                    setState(() {
-                      isOn = value;
-                    });
-                  },
-                ),
-              ],
-            ),
-            const SizedBox(height: 75),
-
-            // 조건부 잠금 설정 UI
-            if (widget.showLockSetting) ...[
-              const CustomLabeledTextField(
-                title: '앨범 잠금 설정',
-                hintText: '사용할 비밀번호를 작성해주세요',
-              ),
-              const SizedBox(height: 60),
-            ],
-
-            // 저장 버튼
-            CustomButton(
-              text: '변경 사항 저장',
-              variant: AppButtonVariant.disabled,
-              onPressed: () {},
-            ),
-          ],
-        ),
-
-        // 툴팁 (Stack의 의미 있는 요소는 이거 하나뿐임)
-        if (_showTooltip)
-          Positioned(
-            top: 40,
-            left: _tooltipLeft,
-            child: TooltipWithArrow(
-              text:
-                  '앨범 생성자가 방장이 되어, 멤버의 편집권한을 관리할 수 있어요.\n실수로 사진이 삭제되거나 앨범이 손상되는 일을 방지할 수 있어요.',
-            ),
-          ),
+        _buildHeader(),
+        // 스위치가 켜져 있고, 멤버 리스트를 보여줘야 할 경우에만 UI를 그림
+        if (isPermissionEnabled && showMemberList) ...[
+          const SizedBox(height: 20),
+          _buildMemberListBox(),
+        ],
       ],
     );
   }
-}
 
-class TooltipWithArrow extends StatelessWidget {
-  final String text;
-
-  const TooltipWithArrow({super.key, required this.text});
-
-  @override
-  Widget build(BuildContext context) {
-    return CustomPaint(
-      painter: TooltipBubblePainter(),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(15, 20, 15, 8),
-        child: Text(
-          text,
-          style: AppFont.size12.copyWith(color: Colors.black, height: 1.0),
+  Widget _buildHeader() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Row(
+          children: [
+            Text(
+              '멤버별 권한 부여',
+              style: AppFont.size18.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(width: 4),
+            const Icon(Icons.info_outline, size: 18, color: AppColor.mainRed),
+          ],
         ),
+        Switch(
+          value: isPermissionEnabled,
+          onChanged: onPermissionToggled,
+          // 스위치가 켜졌을 때 원(thumb)의 색상
+          thumbColor: MaterialStateProperty.resolveWith<Color>((states) {
+            if (states.contains(MaterialState.selected)) {
+              return AppColor.mainRed; // 켜졌을 때 색상
+            }
+            return null; // 꺼졌을 때는 기본값 사용
+          }),
+          // 스위치가 켜졌을 때 배경 트랙의 색상
+          trackColor: MaterialStateProperty.resolveWith<Color>((states) {
+            if (states.contains(MaterialState.selected)) {
+              // 일반적으로 트랙은 원보다 약간 투명하게 설정합니다.
+              return AppColor.mainRed.withOpacity(0.5);
+            }
+            return null; // 꺼졌을 때는 기본값 사용
+          }),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMemberListBox() {
+    return Container(
+      height: 350,
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 15),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey.shade300),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        children: [
+          SizedBox(height: 45, child: TextField(controller: searchController!)),
+          const SizedBox(height: 20),
+          Expanded(
+            child: ListView.separated(
+              itemCount: members!.length,
+              itemBuilder: (context, index) =>
+                  _buildMemberListItem(members![index]),
+              separatorBuilder: (context, index) => const SizedBox(height: 25),
+            ),
+          ),
+        ],
       ),
     );
   }
-}
 
-class TooltipBubblePainter extends CustomPainter {
-  @override
-  void paint(Canvas canvas, Size size) {
-    final double radius = 12;
-    final double arrowW = 12;
-    final double arrowH = 8;
-    final double arrowLeft = 113;
-
-    final Paint paint = Paint()
-      ..color = Colors.white
-      ..style = PaintingStyle.fill;
-
-    final Paint borderPaint = Paint()
-      ..color = AppColor.mainRed
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1;
-
-    final Path path = Path()
-      ..moveTo(radius, arrowH)
-      ..lineTo(arrowLeft, arrowH)
-      ..lineTo(arrowLeft + arrowW / 2, 0)
-      ..lineTo(arrowLeft + arrowW, arrowH)
-      ..lineTo(size.width - radius, arrowH)
-      ..quadraticBezierTo(size.width, arrowH, size.width, arrowH + radius)
-      ..lineTo(size.width, size.height - radius)
-      ..quadraticBezierTo(
-        size.width,
-        size.height,
-        size.width - radius,
-        size.height,
-      )
-      ..lineTo(radius, size.height)
-      ..quadraticBezierTo(0, size.height, 0, size.height - radius)
-      ..lineTo(0, arrowH + radius)
-      ..quadraticBezierTo(0, arrowH, radius, arrowH)
-      ..close();
-
-    canvas.drawPath(path, paint);
-    canvas.drawPath(path, borderPaint);
+  Widget _buildMemberListItem(Member member) {
+    const roles = ['방장', '일반회원', '읽기 전용'];
+    return SizedBox(
+      height: 45,
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 10,
+            backgroundImage: NetworkImage(member.profileImageUrl),
+          ),
+          const SizedBox(width: 10),
+          Text(member.name, style: AppFont.size16),
+          const Spacer(),
+          TextButton(
+            onPressed: () => onKickMember!(member),
+            child: Text(
+              '내보내기',
+              style: AppFont.size14.copyWith(
+                color: AppColor.mainRed,
+                decoration: TextDecoration.underline,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          DropdownButton<String>(
+            value: member.role,
+            underline: const SizedBox.shrink(),
+            items: roles
+                .map(
+                  (String value) => DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(value, style: AppFont.size14),
+                  ),
+                )
+                .toList(),
+            onChanged: (String? newValue) {
+              if (newValue != null) onUpdateRole!(member, newValue);
+            },
+          ),
+        ],
+      ),
+    );
   }
-
-  @override
-  bool shouldRepaint(CustomPainter oldDelegate) => false;
 }

--- a/lib/presentation/screens/main/album/components/album_permission_toggle.dart
+++ b/lib/presentation/screens/main/album/components/album_permission_toggle.dart
@@ -69,19 +69,39 @@ class AlbumPermissionToggle extends StatelessWidget {
       height: 350,
       padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 15),
       decoration: BoxDecoration(
+        color: Colors.white,
         border: Border.all(color: Colors.grey.shade300),
         borderRadius: BorderRadius.circular(10),
       ),
       child: Column(
         children: [
-          SizedBox(height: 45, child: TextField(controller: searchController!)),
+          // [수정] 검색창 UI 개선
+          TextField(
+            controller: searchController,
+            decoration: InputDecoration(
+              hintText: '멤버 검색',
+              hintStyle: AppFont.size16.copyWith(color: Colors.grey.shade500),
+              filled: true,
+              fillColor: const Color(0xFFF8F8F8), // 밝은 회색 배경
+              suffixIcon: const Icon(Icons.search, color: Colors.grey),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide.none,
+              ),
+              contentPadding: const EdgeInsets.symmetric(
+                vertical: 10,
+                horizontal: 15,
+              ),
+            ),
+          ),
           const SizedBox(height: 20),
           Expanded(
             child: ListView.separated(
               itemCount: members!.length,
               itemBuilder: (context, index) =>
                   _buildMemberListItem(members![index]),
-              separatorBuilder: (context, index) => const SizedBox(height: 25),
+              // [수정] 리스트 아이템 간 간격 축소
+              separatorBuilder: (context, index) => const SizedBox(height: 15),
             ),
           ),
         ],
@@ -116,6 +136,13 @@ class AlbumPermissionToggle extends StatelessWidget {
           DropdownButton<String>(
             value: member.role,
             underline: const SizedBox.shrink(),
+            isDense: true,
+            icon: Icon(
+              Icons.keyboard_arrow_down,
+              color: Colors.grey.shade700,
+              size: 20,
+            ),
+            style: AppFont.size14.copyWith(color: Colors.grey.shade700),
             items: roles
                 .map(
                   (String value) => DropdownMenuItem<String>(

--- a/lib/presentation/screens/main/album/components/album_permission_toggle.dart
+++ b/lib/presentation/screens/main/album/components/album_permission_toggle.dart
@@ -32,7 +32,6 @@ class AlbumPermissionToggle extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _buildHeader(),
-        // 스위치가 켜져 있고, 멤버 리스트를 보여줘야 할 경우에만 UI를 그림
         if (isPermissionEnabled && showMemberList) ...[
           const SizedBox(height: 20),
           _buildMemberListBox(),
@@ -75,14 +74,13 @@ class AlbumPermissionToggle extends StatelessWidget {
       ),
       child: Column(
         children: [
-          // [수정] 검색창 UI 개선
           TextField(
             controller: searchController,
             decoration: InputDecoration(
               hintText: '멤버 검색',
               hintStyle: AppFont.size16.copyWith(color: Colors.grey.shade500),
               filled: true,
-              fillColor: const Color(0xFFF8F8F8), // 밝은 회색 배경
+              fillColor: const Color(0xFFF8F8F8),
               suffixIcon: const Icon(Icons.search, color: Colors.grey),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(8),
@@ -100,7 +98,6 @@ class AlbumPermissionToggle extends StatelessWidget {
               itemCount: members!.length,
               itemBuilder: (context, index) =>
                   _buildMemberListItem(members![index]),
-              // [수정] 리스트 아이템 간 간격 축소
               separatorBuilder: (context, index) => const SizedBox(height: 15),
             ),
           ),

--- a/lib/presentation/screens/main/album/components/album_permission_toggle.dart
+++ b/lib/presentation/screens/main/album/components/album_permission_toggle.dart
@@ -57,22 +57,8 @@ class AlbumPermissionToggle extends StatelessWidget {
         ),
         Switch(
           value: isPermissionEnabled,
+          activeThumbColor: AppColor.mainRed,
           onChanged: onPermissionToggled,
-          // 스위치가 켜졌을 때 원(thumb)의 색상
-          thumbColor: MaterialStateProperty.resolveWith<Color>((states) {
-            if (states.contains(MaterialState.selected)) {
-              return AppColor.mainRed; // 켜졌을 때 색상
-            }
-            return null; // 꺼졌을 때는 기본값 사용
-          }),
-          // 스위치가 켜졌을 때 배경 트랙의 색상
-          trackColor: MaterialStateProperty.resolveWith<Color>((states) {
-            if (states.contains(MaterialState.selected)) {
-              // 일반적으로 트랙은 원보다 약간 투명하게 설정합니다.
-              return AppColor.mainRed.withOpacity(0.5);
-            }
-            return null; // 꺼졌을 때는 기본값 사용
-          }),
         ),
       ],
     );

--- a/lib/presentation/screens/main/album/edit/album_edit_screen.dart
+++ b/lib/presentation/screens/main/album/edit/album_edit_screen.dart
@@ -69,7 +69,6 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
                   const AlbumTypeSelector(),
                   const SizedBox(height: 50),
 
-                  // [수정] 기존 멤버 관리 UI를 컴포넌트로 대체
                   AlbumPermissionToggle(
                     isPermissionEnabled: _viewModel.isPermissionEnabled,
                     onPermissionToggled: _viewModel.togglePermission,
@@ -77,7 +76,7 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
                     searchController: _viewModel.searchController,
                     onUpdateRole: _viewModel.updateMemberRole,
                     onKickMember: _viewModel.kickMember,
-                    showMemberList: true, // 설정 화면에서는 멤버 리스트를 보여줌
+                    showMemberList: true,
                   ),
                   const SizedBox(height: 40),
 
@@ -98,8 +97,6 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
     );
   }
 
-  // [제거] _buildMemberManagementSection, _buildMemberListBox, _buildMemberListItem 함수 삭제
-
   Widget _buildBottomButtons() {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -114,8 +111,19 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
+              padding: EdgeInsets.zero, // 버튼 내부 패딩 제거
             ),
-            child: Text('앨범 삭제', style: AppFont.size16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  '앨범 삭제',
+                  style: AppFont.size16.copyWith(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(width: 6),
+                const Icon(Icons.delete, size: 16, color: Colors.white),
+              ],
+            ),
           ),
         ),
         const SizedBox(width: 20),
@@ -129,8 +137,25 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
+              padding: EdgeInsets.zero, // 버튼 내부 패딩 제거
             ),
-            child: Text('앨범 구독 해지', style: AppFont.size16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  '앨범 구독 해지',
+                  // [수정] fontWeight 추가
+                  style: AppFont.size16.copyWith(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(width: 6),
+                // [추가] 아이콘 추가
+                const Icon(
+                  Icons.remove_circle_outline,
+                  size: 16,
+                  color: Colors.white,
+                ),
+              ],
+            ),
           ),
         ),
       ],

--- a/lib/presentation/screens/main/album/edit/album_edit_screen.dart
+++ b/lib/presentation/screens/main/album/edit/album_edit_screen.dart
@@ -7,6 +7,7 @@ import 'package:cherrypic/presentation/screens/main/album/components/album_type_
 import 'package:cherrypic/presentation/screens/main/album/edit/album_edit_view_model.dart';
 import 'package:cherrypic/presentation/screens/main/album/components/album_permission_toggle.dart';
 import 'package:cherrypic/presentation/widgets/custom_button.dart';
+import 'package:cherrypic/presentation/widgets/dialogs/album_delete_dialog.dart';
 
 class AlbumEditScreen extends StatefulWidget {
   final int albumId;
@@ -29,6 +30,16 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
   void dispose() {
     _viewModel.dispose();
     super.dispose();
+  }
+
+  // --- 앨범 삭제 확인 다이얼로그를 표시하는 함수 ---
+  void _showAlbumDeleteDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext dialogContext) {
+        return AlbumDeleteDialog(viewModel: _viewModel);
+      },
+    );
   }
 
   @override
@@ -104,7 +115,7 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
           width: 115,
           height: 40,
           child: ElevatedButton(
-            onPressed: () {},
+            onPressed: _showAlbumDeleteDialog, // 다이얼로그 호출
             style: ElevatedButton.styleFrom(
               backgroundColor: AppColor.mainRed,
               shape: RoundedRectangleBorder(
@@ -117,10 +128,17 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
               children: [
                 Text(
                   '앨범 삭제',
-                  style: AppFont.size16.copyWith(fontWeight: FontWeight.w600),
+                  style: AppFont.size16.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
                 ),
                 const SizedBox(width: 6),
-                const Icon(Icons.delete, size: 16, color: Colors.white),
+                Image.asset(
+                  'assets/images/trash_icon.png',
+                  width: 24,
+                  height: 24,
+                ),
               ],
             ),
           ),
@@ -143,7 +161,10 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
               children: [
                 Text(
                   '앨범 구독 해지',
-                  style: AppFont.size16.copyWith(fontWeight: FontWeight.w600),
+                  style: AppFont.size16.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
                 ),
                 const SizedBox(width: 6),
                 const Icon(

--- a/lib/presentation/screens/main/album/edit/album_edit_screen.dart
+++ b/lib/presentation/screens/main/album/edit/album_edit_screen.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:cherrypic/core/constants/font.dart';
+import 'package:cherrypic/core/constants/color.dart';
+import 'package:cherrypic/presentation/screens/main/album/components/album_cover_section.dart';
+import 'package:cherrypic/presentation/screens/main/album/components/album_type_selector.dart';
+import 'package:cherrypic/presentation/screens/main/album/edit/album_edit_view_model.dart';
+// [수정] AlbumPermissionToggle 경로
+import 'package:cherrypic/presentation/screens/main/album/components/album_permission_toggle.dart';
+import 'package:cherrypic/presentation/widgets/custom_button.dart';
+
+class AlbumEditScreen extends StatefulWidget {
+  final int albumId;
+  const AlbumEditScreen({super.key, required this.albumId});
+
+  @override
+  State<AlbumEditScreen> createState() => _AlbumEditScreenState();
+}
+
+class _AlbumEditScreenState extends State<AlbumEditScreen> {
+  late final AlbumEditViewModel _viewModel;
+
+  @override
+  void initState() {
+    super.initState();
+    _viewModel = AlbumEditViewModel(albumId: widget.albumId);
+  }
+
+  @override
+  void dispose() {
+    _viewModel.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _viewModel,
+      builder: (context, child) {
+        return Scaffold(
+          appBar: AppBar(
+            backgroundColor: Colors.white,
+            elevation: 0,
+            centerTitle: true,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back, color: Colors.black),
+              onPressed: () => context.pop(),
+            ),
+            title: Text(
+              '앨범 설정',
+              style: AppFont.size20.copyWith(
+                color: Colors.black,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+          body: SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 30),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: AlbumCoverSection(
+                      viewModel: _viewModel.albumCoverViewModel,
+                    ),
+                  ),
+                  const SizedBox(height: 80),
+                  const AlbumTypeSelector(),
+                  const SizedBox(height: 50),
+
+                  // [수정] 기존 멤버 관리 UI를 컴포넌트로 대체
+                  AlbumPermissionToggle(
+                    isPermissionEnabled: _viewModel.isPermissionEnabled,
+                    onPermissionToggled: _viewModel.togglePermission,
+                    members: _viewModel.filteredMembers,
+                    searchController: _viewModel.searchController,
+                    onUpdateRole: _viewModel.updateMemberRole,
+                    onKickMember: _viewModel.kickMember,
+                    showMemberList: true, // 설정 화면에서는 멤버 리스트를 보여줌
+                  ),
+                  const SizedBox(height: 40),
+
+                  CustomButton(
+                    text: '변경 사항 저장',
+                    onPressed: () {},
+                    variant: AppButtonVariant.outlined,
+                  ),
+                  const SizedBox(height: 50),
+
+                  _buildBottomButtons(),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  // [제거] _buildMemberManagementSection, _buildMemberListBox, _buildMemberListItem 함수 삭제
+
+  Widget _buildBottomButtons() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: 115,
+          height: 40,
+          child: ElevatedButton(
+            onPressed: () {},
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColor.mainRed,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+            child: Text('앨범 삭제', style: AppFont.size16),
+          ),
+        ),
+        const SizedBox(width: 20),
+        SizedBox(
+          width: 150,
+          height: 40,
+          child: ElevatedButton(
+            onPressed: () {},
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColor.mainRed,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+            child: Text('앨범 구독 해지', style: AppFont.size16),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/screens/main/album/edit/album_edit_screen.dart
+++ b/lib/presentation/screens/main/album/edit/album_edit_screen.dart
@@ -5,7 +5,6 @@ import 'package:cherrypic/core/constants/color.dart';
 import 'package:cherrypic/presentation/screens/main/album/components/album_cover_section.dart';
 import 'package:cherrypic/presentation/screens/main/album/components/album_type_selector.dart';
 import 'package:cherrypic/presentation/screens/main/album/edit/album_edit_view_model.dart';
-// [수정] AlbumPermissionToggle 경로
 import 'package:cherrypic/presentation/screens/main/album/components/album_permission_toggle.dart';
 import 'package:cherrypic/presentation/widgets/custom_button.dart';
 
@@ -111,7 +110,7 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
-              padding: EdgeInsets.zero, // 버튼 내부 패딩 제거
+              padding: EdgeInsets.zero,
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -137,18 +136,16 @@ class _AlbumEditScreenState extends State<AlbumEditScreen> {
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
-              padding: EdgeInsets.zero, // 버튼 내부 패딩 제거
+              padding: EdgeInsets.zero,
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Text(
                   '앨범 구독 해지',
-                  // [수정] fontWeight 추가
                   style: AppFont.size16.copyWith(fontWeight: FontWeight.w600),
                 ),
                 const SizedBox(width: 6),
-                // [추가] 아이콘 추가
                 const Icon(
                   Icons.remove_circle_outline,
                   size: 16,

--- a/lib/presentation/screens/main/album/edit/album_edit_view_model.dart
+++ b/lib/presentation/screens/main/album/edit/album_edit_view_model.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'dart:math';
+import 'package:cherrypic/presentation/screens/main/album/components/album_cover_view_model.dart';
+
+// --- Mock Data ---
+class MockAlbum {
+  final int id;
+  final String name;
+  final String coverImageUrl;
+
+  MockAlbum({
+    required this.id,
+    required this.name,
+    required this.coverImageUrl,
+  });
+}
+
+final Map<int, MockAlbum> mockAlbumDatabase = {
+  1: MockAlbum(
+    id: 1,
+    name: '음식',
+    coverImageUrl:
+        'https://images.unsplash.com/photo-1504674900247-0877df9cc836',
+  ),
+  2: MockAlbum(
+    id: 2,
+    name: '여행',
+    coverImageUrl:
+        'https://images.unsplash.com/photo-1476514525535-07fb3b4ae5f1',
+  ),
+  3: MockAlbum(
+    id: 3,
+    name: '반려동물',
+    coverImageUrl:
+        'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba',
+  ),
+};
+// --- End of Mock Data ---
+
+// Member 데이터 모델
+class Member {
+  final int id;
+  final String name;
+  final String profileImageUrl;
+  String role;
+
+  Member({
+    required this.id,
+    required this.name,
+    required this.profileImageUrl,
+    required this.role,
+  });
+}
+
+class AlbumEditViewModel extends ChangeNotifier {
+  final int albumId;
+  late final AlbumCoverViewModel albumCoverViewModel;
+
+  List<Member> _allMembers = [];
+  List<Member> _filteredMembers = [];
+  List<Member> get filteredMembers => _filteredMembers;
+
+  final TextEditingController searchController = TextEditingController();
+  bool _isPermissionEnabled = true;
+  bool get isPermissionEnabled => _isPermissionEnabled;
+
+  AlbumEditViewModel({required this.albumId}) {
+    _loadInitialData(albumId);
+    searchController.addListener(_onSearchChanged);
+  }
+
+  @override
+  void dispose() {
+    searchController.removeListener(_onSearchChanged);
+    searchController.dispose();
+    albumCoverViewModel.dispose();
+    super.dispose();
+  }
+
+  void _loadInitialData(int currentAlbumId) {
+    final albumData =
+        mockAlbumDatabase[currentAlbumId] ??
+        MockAlbum(id: currentAlbumId, name: '새 앨범', coverImageUrl: '');
+
+    albumCoverViewModel = AlbumCoverViewModel();
+    albumCoverViewModel.updateAlbumName(albumData.name);
+    albumCoverViewModel.setCoverImageUrl(albumData.coverImageUrl);
+
+    _allMembers = List.generate(5 + (currentAlbumId % 5), (index) {
+      final roles = ['방장', '일반회원', '읽기 전용'];
+      return Member(
+        id: index,
+        name: '멤버 ${index + 1}',
+        profileImageUrl: 'https://placehold.co/40x40/EFEFEF/AAAAAA?text=P',
+        role: roles[Random().nextInt(roles.length)],
+      );
+    });
+    if (_allMembers.isNotEmpty) _allMembers[0].role = '방장';
+    _filteredMembers = _allMembers;
+
+    _isPermissionEnabled = true;
+
+    notifyListeners();
+  }
+
+  void _onSearchChanged() {
+    final query = searchController.text.toLowerCase().trim();
+    if (query.isEmpty) {
+      _filteredMembers = _allMembers;
+    } else {
+      _filteredMembers = _allMembers
+          .where((member) => member.name.toLowerCase().contains(query))
+          .toList();
+    }
+    notifyListeners();
+  }
+
+  void updateMemberRole(Member member, String newRole) {
+    final index = _allMembers.indexWhere((m) => m.id == member.id);
+    if (index != -1) {
+      _allMembers[index].role = newRole;
+      final filteredIndex = _filteredMembers.indexWhere(
+        (m) => m.id == member.id,
+      );
+      if (filteredIndex != -1) _filteredMembers[filteredIndex].role = newRole;
+      notifyListeners();
+    }
+  }
+
+  void kickMember(Member member) {
+    _allMembers.removeWhere((m) => m.id == member.id);
+    _filteredMembers.removeWhere((m) => m.id == member.id);
+    notifyListeners();
+  }
+
+  void togglePermission(bool value) {
+    _isPermissionEnabled = value;
+    notifyListeners();
+  }
+}

--- a/lib/presentation/screens/main/detail/Header/main_album_header.dart
+++ b/lib/presentation/screens/main/detail/Header/main_album_header.dart
@@ -21,16 +21,13 @@ class MainAlbumHeader extends StatelessWidget {
         child: Column(
           children: [
             CustomAlbumAppBar(
-              // data 모델에서 제목, 뱃지 타입 등을 가져오도록 수정
               title: data.title,
               profileImagePath: 'assets/images/albumCover.png',
               badgeType: AlbumBadgeType.pro,
-              // [이 부분 추가] 설정 버튼을 눌렀을 때의 동작 정의
               onSettings: () {
-                // 현재 앨범의 ID를 가지고 앨범 설정 페이지로 이동합니다.
                 final path = RoutePath.albumSetting.replaceFirst(
                   ':albumId',
-                  data.albumId.toString(), // data 모델에서 현재 앨범 ID를 가져옴
+                  data.albumId.toString(),
                 );
                 context.push(path);
               },

--- a/lib/presentation/screens/main/detail/Header/main_album_header.dart
+++ b/lib/presentation/screens/main/detail/Header/main_album_header.dart
@@ -1,9 +1,11 @@
 // main_album_header.dart
+import 'package:cherrypic/core/router/route_path.dart';
 import 'package:cherrypic/presentation/widgets/album/album_badge_type.dart';
 import 'package:cherrypic/presentation/widgets/custom_album_app_bar.dart';
 import 'package:cherrypic/presentation/screens/main/detail/Header/components/custom_album_badge.dart';
 import 'package:cherrypic/presentation/widgets/custom_gauge_bar.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'album_header_model.dart';
 
 class MainAlbumHeader extends StatelessWidget {
@@ -19,9 +21,19 @@ class MainAlbumHeader extends StatelessWidget {
         child: Column(
           children: [
             CustomAlbumAppBar(
-              title: '음식(양식, 중식, 한식...)',
+              // data 모델에서 제목, 뱃지 타입 등을 가져오도록 수정
+              title: data.title,
               profileImagePath: 'assets/images/albumCover.png',
               badgeType: AlbumBadgeType.pro,
+              // [이 부분 추가] 설정 버튼을 눌렀을 때의 동작 정의
+              onSettings: () {
+                // 현재 앨범의 ID를 가지고 앨범 설정 페이지로 이동합니다.
+                final path = RoutePath.albumSetting.replaceFirst(
+                  ':albumId',
+                  data.albumId.toString(), // data 모델에서 현재 앨범 ID를 가져옴
+                );
+                context.push(path);
+              },
             ),
             Stack(
               children: [

--- a/lib/presentation/screens/main/home_tab/album_section.dart
+++ b/lib/presentation/screens/main/home_tab/album_section.dart
@@ -1,3 +1,4 @@
+import 'package:cherrypic/core/router/route_path.dart';
 import 'package:flutter/material.dart';
 import 'package:cherrypic/presentation/widgets/album/album_card.dart';
 import 'package:cherrypic/presentation/widgets/album/album_badge_type.dart';
@@ -14,6 +15,38 @@ class _AlbumSectionState extends State<AlbumSection> {
   late final List<String> titles;
   late final List<AlbumBadgeType> badges;
   late List<bool> likedList;
+  final List<Map<String, dynamic>> albums = [
+    {
+      'id': 1,
+      'title': '가족여행',
+      'badgeType': AlbumBadgeType.basic,
+      'isLiked': false,
+    },
+    {
+      'id': 2,
+      'title': '맛집탐방',
+      'badgeType': AlbumBadgeType.pro,
+      'isLiked': true,
+    },
+    {
+      'id': 3,
+      'title': '반려동물',
+      'badgeType': AlbumBadgeType.premium,
+      'isLiked': false,
+    },
+    {
+      'id': 4,
+      'title': '운동기록',
+      'badgeType': AlbumBadgeType.basic,
+      'isLiked': true,
+    },
+    {
+      'id': 5,
+      'title': '데일리룩',
+      'badgeType': AlbumBadgeType.pro,
+      'isLiked': false,
+    },
+  ];
 
   @override
   void initState() {
@@ -58,30 +91,36 @@ class _AlbumSectionState extends State<AlbumSection> {
     return Scaffold(
       body: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
-
         child: Align(
           alignment: Alignment.center,
           child: Wrap(
-            spacing: 20,
-            runSpacing: 35,
-            children: List.generate(titles.length, (index) {
+            spacing: 20, // 가로 아이템 간의 간격
+            runSpacing: 35, // 세로 아이템 간의 간격
+            children: List.generate(albums.length, (index) {
+              final album = albums[index];
               return SizedBox(
                 width: 150,
                 child: AlbumCard(
-                  imageUrl: '',
-                  title: titles[index],
-                  badgeType: badges[index],
-                  isLiked: likedList[index],
+                  imageUrl: '', // TODO: 실제 앨범 커버 이미지 URL로 변경
+                  title: album['title'],
+                  badgeType: album['badgeType'],
+                  isLiked: album['isLiked'],
                   onTap: () {
-                    final id = (index + 1).toString();
-                    context.push('/album/$id');
+                    // [수정] 각 앨범의 고유 ID를 사용하여 경로를 동적으로 생성
+                    final albumId = album['id'].toString();
+                    final path = RoutePath.albumDetail.replaceFirst(
+                      ':albumId',
+                      albumId,
+                    );
+                    context.push(path);
                   },
-
                   onLikeToggle: () {
+                    // 좋아요 상태를 변경
                     setState(() {
-                      likedList[index] = !likedList[index];
+                      album['isLiked'] = !album['isLiked'];
                     });
                   },
+                  // isSelected는 필요에 따라 사용 (현재는 true로 고정)
                   isSelected: true,
                 ),
               );

--- a/lib/presentation/widgets/custom_button.dart
+++ b/lib/presentation/widgets/custom_button.dart
@@ -3,6 +3,7 @@ import 'package:cherrypic/core/constants/font.dart';
 import 'package:flutter/material.dart';
 
 enum AppButtonVariant { filled, outlined, disabled, outlinedStatic, address }
+
 enum AppButtonShape { rounded, squared, capsule }
 
 enum CustomButtonType {
@@ -63,7 +64,7 @@ class CustomButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final bool isDisabled =
         variant == AppButtonVariant.disabled ||
-            (onPressed == null && variant != AppButtonVariant.outlinedStatic);
+        (onPressed == null && variant != AppButtonVariant.outlinedStatic);
 
     Color bgColor;
     Color fgColor;
@@ -111,21 +112,30 @@ class CustomButton extends StatelessWidget {
 
     final styleByType = _getStyleByType(type);
 
-    final child = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(
-          text?.isNotEmpty == true ? text! : styleByType.text,
-          style: styleByType.fontStyle.copyWith(
-            fontWeight: type == CustomButtonType.addAddress ? FontWeight.w500 : FontWeight.w800,
-          ),
-        ),
-        if (iconPath != null) ...[
-          const SizedBox(width: 0),
+    // [수정] 아이콘 유무에 따라 child를 다르게 구성
+    final textWidget = Text(
+      text?.isNotEmpty == true ? text! : styleByType.text,
+      style: styleByType.fontStyle.copyWith(
+        fontWeight: type == CustomButtonType.addAddress
+            ? FontWeight.w500
+            : FontWeight.w800,
+      ),
+    );
+
+    final Widget child;
+    if (iconPath != null) {
+      child = Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          textWidget,
+          const SizedBox(width: 8),
           Image.asset(iconPath!, width: 24, height: 24),
         ],
-      ],
-    );
+      );
+    } else {
+      child = textWidget;
+    }
 
     final style = ButtonStyle(
       backgroundColor: WidgetStateProperty.all(bgColor),
@@ -140,22 +150,24 @@ class CustomButton extends StatelessWidget {
           side: border ?? BorderSide.none,
         ),
       ),
+      elevation: WidgetStateProperty.all(0),
     );
 
     final button = variant == AppButtonVariant.outlined
         ? OutlinedButton(
-      onPressed: isDisabled ? null : onPressed,
-      style: style,
-      child: child,
-    )
+            onPressed: isDisabled ? null : onPressed,
+            style: style,
+            child: child,
+          )
         : ElevatedButton(
-      onPressed: isDisabled ? null : onPressed,
-      style: style,
-      child: child,
-    );
+            onPressed: isDisabled ? null : onPressed,
+            style: style,
+            child: child,
+          );
 
     return SizedBox(
-      width: width ?? styleByType.width ?? MediaQuery.of(context).size.width - 40,
+      width:
+          width ?? styleByType.width ?? MediaQuery.of(context).size.width - 40,
       child: button,
     );
   }

--- a/lib/presentation/widgets/dialogs/album_delete_dialog.dart
+++ b/lib/presentation/widgets/dialogs/album_delete_dialog.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:cherrypic/core/constants/color.dart';
+import 'package:cherrypic/core/constants/font.dart';
+import 'package:cherrypic/presentation/screens/main/album/edit/album_edit_view_model.dart';
+
+class AlbumDeleteDialog extends StatelessWidget {
+  final AlbumEditViewModel viewModel;
+
+  const AlbumDeleteDialog({super.key, required this.viewModel});
+
+  @override
+  Widget build(BuildContext context) {
+    final albumName = viewModel.albumCoverViewModel.albumName;
+    final coverUrl = viewModel.albumCoverViewModel.coverImageUrl;
+    const String ownerName = '방장';
+
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      backgroundColor: Colors.white,
+      child: Container(
+        width: 340,
+        padding: const EdgeInsets.fromLTRB(20, 24, 20, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // --- 헤더 ---
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      '앨범 삭제 안내',
+                      style: AppFont.size18.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: AppColor.mainRed,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    const Icon(
+                      Icons.warning_amber_rounded,
+                      color: AppColor.mainRed,
+                      size: 20,
+                    ),
+                  ],
+                ),
+                IconButton(
+                  splashRadius: 20,
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                  icon: const Icon(Icons.close, color: Colors.black54),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+
+            // --- 앨범 커버 미리보기 ---
+            _buildAlbumPreview(coverUrl, albumName),
+            const SizedBox(height: 12),
+
+            // --- 방장 및 삭제일 정보 ---
+            Text('방장 홍길동', style: AppFont.size14.copyWith(color: Colors.black)),
+            const SizedBox(height: 4),
+            Text(
+              '삭제일 2025. 09. 14',
+              style: AppFont.size14.copyWith(color: Colors.black),
+            ),
+            const SizedBox(height: 24),
+
+            // --- 안내 문구 ---
+            Text.rich(
+              TextSpan(
+                style: AppFont.size14.copyWith(
+                  height: 1.5,
+                  color: Colors.black87,
+                ),
+                children: [
+                  TextSpan(
+                    text: ownerName,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const TextSpan(text: '님이 '),
+                  TextSpan(
+                    text: albumName,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const TextSpan(
+                    text: ' 앨범을 삭제하려고 합니다.\n중요한 사진은 미리 다운로드 받은 뒤\n앨범에서 나가주세요.',
+                  ),
+                ],
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+
+            // --- 버튼 ---
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _buildButton(
+                  context: context,
+                  text: '취소',
+                  isConfirm: false,
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+                const SizedBox(width: 12),
+                _buildButton(
+                  context: context,
+                  text: '앨범 나가기',
+                  isConfirm: true,
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAlbumPreview(String? coverUrl, String albumName) {
+    return Container(
+      width: 160,
+      height: 220,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.withAlpha(35),
+            blurRadius: 5,
+            spreadRadius: 1,
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          // 이미지 부분
+          Container(
+            width: 160,
+            height: 170,
+            decoration: const BoxDecoration(
+              borderRadius: BorderRadius.vertical(top: Radius.circular(8)),
+            ),
+            child: ClipRRect(
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(8),
+              ),
+              child: (coverUrl != null && coverUrl.isNotEmpty)
+                  ? Image.network(
+                      coverUrl,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) =>
+                          Container(color: Colors.grey.shade200),
+                    )
+                  : Container(color: Colors.grey.shade200),
+            ),
+          ),
+          // 텍스트 부분
+          Expanded(
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              alignment: Alignment.center,
+              child: Text(
+                albumName,
+                style: AppFont.size14,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildButton({
+    required BuildContext context,
+    required String text,
+    required bool isConfirm,
+    required VoidCallback onPressed,
+  }) {
+    return SizedBox(
+      width: 130,
+      height: 44,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: isConfirm ? AppColor.mainRed : Colors.white,
+          foregroundColor: isConfirm ? Colors.white : AppColor.mainRed,
+          side: isConfirm
+              ? BorderSide.none
+              : const BorderSide(color: AppColor.mainRed, width: 1.5),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          elevation: 0,
+        ),
+        child: Text(
+          text,
+          style: AppFont.size16.copyWith(fontWeight: FontWeight.w600),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/dialogs/custom_confirm_dialog.dart
+++ b/lib/presentation/widgets/dialogs/custom_confirm_dialog.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:cherrypic/core/constants/color.dart';
+import 'package:cherrypic/core/constants/font.dart';
+
+class CustomConfirmDialog extends StatelessWidget {
+  final String title;
+  final String content;
+  final String confirmButtonText;
+  final String cancelButtonText;
+  final VoidCallback onConfirm;
+
+  const CustomConfirmDialog({
+    super.key,
+    required this.title,
+    required this.content,
+    this.confirmButtonText = '확인',
+    this.cancelButtonText = '취소',
+    required this.onConfirm,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    String memberName = '';
+    String remainingContent = content;
+    final nameMatch = RegExp(r'^(.*?)\s님을').firstMatch(content);
+    if (nameMatch != null) {
+      memberName = nameMatch.group(1)!;
+      remainingContent = content.substring(nameMatch.end);
+    }
+
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      backgroundColor: Colors.white,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(20, 24, 20, 20),
+        width: 320,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // --- 타이틀 및 닫기 버튼 ---
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      title,
+                      style: AppFont.size18.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: AppColor.mainRed,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Image.asset(
+                      'assets/images/door_open.png',
+                      width: 28,
+                      height: 28,
+                    ),
+                  ],
+                ),
+                IconButton(
+                  splashRadius: 20,
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                  icon: const Icon(Icons.close, color: Colors.black54),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+            const SizedBox(height: 30),
+
+            Text.rich(
+              TextSpan(
+                style: AppFont.size16.copyWith(
+                  height: 1.5,
+                  color: Colors.black,
+                ),
+                children: [
+                  if (memberName.isNotEmpty)
+                    TextSpan(
+                      text: memberName,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  TextSpan(text: remainingContent),
+                ],
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 30),
+
+            // --- 버튼 ---
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _buildButton(
+                  context: context,
+                  text: cancelButtonText,
+                  isConfirm: false,
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+                const SizedBox(width: 12),
+                _buildButton(
+                  context: context,
+                  text: confirmButtonText,
+                  isConfirm: true,
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    onConfirm();
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildButton({
+    required BuildContext context,
+    required String text,
+    required bool isConfirm,
+    required VoidCallback onPressed,
+  }) {
+    return SizedBox(
+      width: 120,
+      height: 44,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: isConfirm ? AppColor.mainRed : Colors.white,
+          foregroundColor: isConfirm ? Colors.white : AppColor.mainRed,
+          side: isConfirm
+              ? BorderSide.none
+              : const BorderSide(color: AppColor.mainRed, width: 1.5),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          elevation: 0,
+        ),
+        child: Text(
+          text,
+          style: AppFont.size14.copyWith(fontWeight: FontWeight.w600),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -324,26 +324,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -641,10 +641,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -729,10 +729,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   video_player:
     dependency: transitive
     description:


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #23

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- **앨범 생성 상태 관리**
  - `AlbumAddViewModel` 클래스를 도입하여 권한 토글을 포함한 앨범 생성 관련 상태를 관리하도록 했습니다. 이를 `AlbumAddScreen`에 통합하여 반응형 UI 업데이트가 가능하도록 개선했습니다.
- **앨범 커버 미리보기 기능 개선**
  - `AlbumCoverSection`의 앨범 커버 미리보기 로직을 개선하여, 새롭게 선택된 이미지, 기존 네트워크 이미지, 또는 이미지가 없는 경우의 플레이스홀더를 모두 지원하도록 수정했습니다.
  - `AlbumCoverViewModel`에 커버 이미지 URL을 설정하는 메서드를 추가했습니다.
- **앨범 권한 설정 UI 리팩토링**
  - `AlbumPermissionToggle`을 `Stateful` 위젯에서 `Stateless` 위젯으로 리팩토링했습니다. 이제 권한 상태와 콜백 함수를 파라미터로 전달받아 더 유연하게 사용할 수 있습니다.
  - 멤버 목록을 표시하고 관리하는 기능을 추가했으며, 역할 할당 및 확인 다이얼로그를 통한 멤버 삭제 기능이 포함됩니다.
- **멤버 내보내기 & 앨범 나가기 모달 UI 구현** 

![Simulator Screen Recording - iPhone 16 Pro - 2025-08-29 at 15 49 37](https://github.com/user-attachments/assets/acdc56c5-a6aa-4052-8450-4f675a04f2ee)

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- UI나 플로우가 확정 되지 않은 부분들이 좀 있어서, 해당 부분은 일단 제외하고 필요해 보이는 부분 먼저 구현 완료했습니다.