### PR TITLE
[#43] 마이페이지 api 연결 1차 구현

### DIFF
--- a/lib/core/network/api_path.dart
+++ b/lib/core/network/api_path.dart
@@ -9,6 +9,8 @@ class ApiPath {
       '/albums/$albumId/invitation-link';
   static String albumImages(int albumId) => '/albums/$albumId/images';
 
+  static String albumSubscription(int albumId) => '/albums/$albumId/subscriptions';
+
   // 앨범 이벤트
   static const String events = '/events';
   static const String eventsCoverUploadUrl = '/events/cover-upload-url';

--- a/lib/core/network/api_path.dart
+++ b/lib/core/network/api_path.dart
@@ -19,4 +19,5 @@ class ApiPath {
 
   // 멤버 관련 API
   static String memberInfo() => '/members/me';
+  static const String memberProfileImage = '/members/profile-upload-url';
 }

--- a/lib/core/network/api_path.dart
+++ b/lib/core/network/api_path.dart
@@ -22,4 +22,7 @@ class ApiPath {
   // 멤버 관련 API
   static String memberInfo() => '/members/me';
   static const String memberProfileImage = '/members/profile-upload-url';
+
+  // 결제 관련 API
+  static const String albumPaymentInfo = '/payments';
 }

--- a/lib/core/network/api_path.dart
+++ b/lib/core/network/api_path.dart
@@ -16,4 +16,7 @@ class ApiPath {
   static String eventDetail(int eventId) => '/events/$eventId';
 
   // ... 다른 API 경로들도 여기에 추가
+
+  // 멤버 관련 API
+  static String memberInfo() => '/members/me';
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -127,8 +127,14 @@ final Map<String, GoRouterWidgetBuilder> routeBuilders = {
       const AlbumPaymentInfoScreen(),
   RoutePath.myPage_payment_info: (context, state) {
     final item = state.extra as AlbumPaymentInfoModel;
-    // final viewModel = state.extra as PaymentInfoViewModel;
-    return PaymentInfoScreen(item: item, viewModel: PaymentInfoViewModel());
+    final idStr = state.uri.queryParameters['albumId'] ?? '-1';
+    final albumId = int.tryParse(idStr) ?? -1;
+
+    return PaymentInfoScreen(
+      item: item,
+      viewModel: PaymentInfoViewModel(),
+      albumId: albumId,
+    );
   },
   RoutePath.myPage_photo_management: (context, state) =>
   const PhotoManagementScreen(),

--- a/lib/data/album/dto/response/album_payment_info_dto.dart
+++ b/lib/data/album/dto/response/album_payment_info_dto.dart
@@ -1,0 +1,43 @@
+class AlbumPaymentInfoDto {
+  final int paymentId;
+  final String paidAt;
+  final int amount;
+
+  AlbumPaymentInfoDto({
+    required this.paymentId,
+    required this.paidAt,
+    required this.amount,
+  });
+
+  factory AlbumPaymentInfoDto.fromJson(Map<String, dynamic> json) {
+    return AlbumPaymentInfoDto(
+      paymentId: json['paymentId'] as int,
+      paidAt: json['paidAt'] as String,
+      amount: json['amount'] as int,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'paymentId': paymentId,
+      'paidAt': paidAt,
+      'amount': amount,
+    };
+  }
+}
+
+class AlbumPaymentInfoResponseDto {
+  final List<AlbumPaymentInfoDto> content;
+  final bool isLast;
+
+  AlbumPaymentInfoResponseDto({required this.content, required this.isLast});
+
+  factory AlbumPaymentInfoResponseDto.fromJson(Map<String, dynamic> json) {
+    return AlbumPaymentInfoResponseDto(
+      content: (json['content'] as List? ?? [])
+          .map((item) => AlbumPaymentInfoDto.fromJson(item as Map<String, dynamic>))
+          .toList(),
+      isLast: json['isLast'] as bool? ?? true,
+    );
+  }
+}

--- a/lib/data/album/dto/response/album_subscription_info_dto.dart
+++ b/lib/data/album/dto/response/album_subscription_info_dto.dart
@@ -1,0 +1,31 @@
+class AlbumSubscriptionInfoDto {
+  final String subscriptionStartAt;
+  final String subscriptionEndAt;
+  final String subscriptionNextBillingAt;
+  final String status;
+
+  AlbumSubscriptionInfoDto({
+    required this.subscriptionStartAt,
+    required this.subscriptionEndAt,
+    required this.subscriptionNextBillingAt,
+    required this.status,
+  });
+
+  factory AlbumSubscriptionInfoDto.fromJson(Map<String, dynamic> json) {
+    return AlbumSubscriptionInfoDto(
+      subscriptionStartAt: json['subscriptionStartAt'] as String,
+      subscriptionEndAt: json['subscriptionEndAt'] as String,
+      subscriptionNextBillingAt: json['subscriptionNextBillingAt'] as String,
+      status: json['status'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'subscriptionStartAt': subscriptionStartAt,
+      'subscriptionEndAt': subscriptionEndAt,
+      'subscriptionNextBillingAt': subscriptionNextBillingAt,
+      'status': status
+    };
+  }
+}

--- a/lib/data/album/repositories/album_repository.dart
+++ b/lib/data/album/repositories/album_repository.dart
@@ -10,6 +10,8 @@ import 'package:cherrypic/data/album/dto/response/participant_dto.dart';
 import 'package:cherrypic/data/album/dto/response/presigned_url_response_dto.dart';
 import 'package:cherrypic/data/album/services/album_remote_data_source.dart';
 
+import '../dto/response/album_subscription_info_dto.dart';
+
 class AlbumRepository {
   final AlbumRemoteDataSource _remoteDataSource;
 
@@ -126,5 +128,14 @@ class AlbumRepository {
   /// 앨범 삭제
   Future<void> deleteAlbum(int albumId) async {
     return await _remoteDataSource.deleteAlbum(albumId);
+  }
+
+  /// 구독 정보 조회
+  Future<AlbumSubscriptionInfoDto> getAlbumSubscriptionInfo(int albumId) async {
+    try {
+      return await _remoteDataSource.getAlbumSubscriptionInfo(albumId);
+    } catch (e) {
+      rethrow;
+    }
   }
 }

--- a/lib/data/album/repositories/album_repository.dart
+++ b/lib/data/album/repositories/album_repository.dart
@@ -5,6 +5,7 @@ import 'package:cherrypic/data/album/dto/request/album_update_request_dto.dart';
 import 'package:cherrypic/data/album/dto/response/album_dto.dart';
 import 'package:cherrypic/data/album/dto/response/album_detail_dto.dart';
 import 'package:cherrypic/data/album/dto/response/album_image_list_response_dto.dart';
+import 'package:cherrypic/data/album/dto/response/album_payment_info_dto.dart';
 import 'package:cherrypic/data/album/dto/response/invitation_link_dto.dart';
 import 'package:cherrypic/data/album/dto/response/participant_dto.dart';
 import 'package:cherrypic/data/album/dto/response/presigned_url_response_dto.dart';
@@ -137,5 +138,20 @@ class AlbumRepository {
     } catch (e) {
       rethrow;
     }
+  }
+
+  Future<AlbumPaymentInfoResponseDto> getAlbumPaymentInfo(
+      {
+        int? albumId,
+        int? lastPaymentId,
+        int size = 20,
+        String direction = 'DESC',
+      }) async {
+    return await _remoteDataSource.getAlbumPaymentInfo(
+      albumId: albumId,
+      lastPaymentId: lastPaymentId,
+      size: size,
+      direction: direction,
+    );
   }
 }

--- a/lib/data/album/repositories/album_repository.dart
+++ b/lib/data/album/repositories/album_repository.dart
@@ -140,6 +140,7 @@ class AlbumRepository {
     }
   }
 
+  /// 앨범 결제 내역 정보 조회
   Future<AlbumPaymentInfoResponseDto> getAlbumPaymentInfo(
       {
         int? albumId,

--- a/lib/data/album/services/album_remote_data_source.dart
+++ b/lib/data/album/services/album_remote_data_source.dart
@@ -14,6 +14,7 @@ import 'package:cherrypic/data/album/dto/response/participant_dto.dart';
 import 'package:cherrypic/data/album/dto/response/presigned_url_response_dto.dart';
 import 'package:dio/dio.dart';
 
+import '../dto/response/album_payment_info_dto.dart';
 import '../dto/response/album_subscription_info_dto.dart';
 
 class AlbumRemoteDataSource {
@@ -272,6 +273,36 @@ class AlbumRemoteDataSource {
       final apiResponse = ApiResponse.fromJson(
         response.data,
             (json) => AlbumSubscriptionInfoDto.fromJson(json as Map<String, dynamic>),
+      );
+
+      return apiResponse.data!;
+    } on DioException catch (e) {
+      throw ErrorHandler.handle(e);
+    }
+  }
+
+  Future<AlbumPaymentInfoResponseDto> getAlbumPaymentInfo(
+      {
+        int? albumId,
+        int? lastPaymentId,
+        int size = 20,
+        String direction = 'DESC',
+      }) async {
+    try {
+      final response = await _dio.get(
+        ApiPath.albumPaymentInfo,
+        queryParameters: {
+         'albumId' : albumId,
+          'lastPaymentId' : lastPaymentId,
+          'size': size,
+          'direction': direction,
+        },
+      );
+
+      final apiResponse = ApiResponse.fromJson(
+        response.data,
+            (json) =>
+                AlbumPaymentInfoResponseDto.fromJson(json as Map<String, dynamic>),
       );
 
       return apiResponse.data!;

--- a/lib/data/album/services/album_remote_data_source.dart
+++ b/lib/data/album/services/album_remote_data_source.dart
@@ -281,6 +281,7 @@ class AlbumRemoteDataSource {
     }
   }
 
+  /// 앨범 결제 내역 정보 조회
   Future<AlbumPaymentInfoResponseDto> getAlbumPaymentInfo(
       {
         int? albumId,

--- a/lib/data/album/services/album_remote_data_source.dart
+++ b/lib/data/album/services/album_remote_data_source.dart
@@ -14,6 +14,8 @@ import 'package:cherrypic/data/album/dto/response/participant_dto.dart';
 import 'package:cherrypic/data/album/dto/response/presigned_url_response_dto.dart';
 import 'package:dio/dio.dart';
 
+import '../dto/response/album_subscription_info_dto.dart';
+
 class AlbumRemoteDataSource {
   final Dio _dio = DioClient().dio;
 
@@ -257,6 +259,22 @@ class AlbumRemoteDataSource {
   Future<void> deleteAlbum(int albumId) async {
     try {
       await _dio.delete(ApiPath.albumDetail(albumId));
+    } on DioException catch (e) {
+      throw ErrorHandler.handle(e);
+    }
+  }
+
+  /// 구독 정보 조회
+  Future<AlbumSubscriptionInfoDto> getAlbumSubscriptionInfo(int albumId) async {
+    try {
+      final response = await _dio.get(ApiPath.albumSubscription(albumId));
+
+      final apiResponse = ApiResponse.fromJson(
+        response.data,
+            (json) => AlbumSubscriptionInfoDto.fromJson(json as Map<String, dynamic>),
+      );
+
+      return apiResponse.data!;
     } on DioException catch (e) {
       throw ErrorHandler.handle(e);
     }

--- a/lib/data/member/dto/request/member_edit_profile_request_dto.dart
+++ b/lib/data/member/dto/request/member_edit_profile_request_dto.dart
@@ -1,0 +1,13 @@
+class MemberEditProfileRequestDto {
+  final String nickname;
+  final String? profileImageUrl;
+
+  MemberEditProfileRequestDto({required this.nickname, this.profileImageUrl});
+
+  Map<String, dynamic> toJson() {
+    return {
+      'nickname': nickname,
+      if (profileImageUrl != null) 'profileImageUrl': profileImageUrl,
+    };
+  }
+}

--- a/lib/data/member/dto/response/member_edit_profile_dto.dart
+++ b/lib/data/member/dto/response/member_edit_profile_dto.dart
@@ -1,0 +1,23 @@
+class MemberEditProfileDto {
+  final String nickname;
+  final String profileImageUrl;
+
+  MemberEditProfileDto({
+    required this.nickname,
+    required this.profileImageUrl,
+  });
+
+  factory MemberEditProfileDto.fromJson(Map<String, dynamic> json) {
+    return MemberEditProfileDto(
+      nickname: json['nickname'] as String,
+      profileImageUrl: json['profileImageUrl'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'nickname': nickname,
+      'profileImageUrl': profileImageUrl,
+    };
+  }
+}

--- a/lib/data/member/dto/response/member_info_dto.dart
+++ b/lib/data/member/dto/response/member_info_dto.dart
@@ -1,0 +1,43 @@
+class MemberInfoDto {
+  final int memberId;
+  final String oauthProvider;
+  final String nickname;
+  final String profileImageUrl;
+  final String status;
+  final String role;
+  final bool localImageDeletion;
+
+  MemberInfoDto({
+    required this.memberId,
+    required this.oauthProvider,
+    required this.nickname,
+    required this.profileImageUrl,
+    required this.status,
+    required this.role,
+    required this.localImageDeletion
+  });
+
+  factory MemberInfoDto.fromJson(Map<String, dynamic> json) {
+    return MemberInfoDto(
+      memberId: json['memberId'] as int,
+      oauthProvider: json['oauthProvider'] as String,
+      nickname: json['nickname'] as String,
+      profileImageUrl: json['profileImageUrl'] as String,
+      status: json['status'] as String,
+      role: json['role'] as String,
+      localImageDeletion: json['localImageDeletion'] as bool,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'memberId': memberId,
+      'oauthProvider': oauthProvider,
+      'nickname': nickname,
+      'profileImageUrl': profileImageUrl,
+      'status': status,
+      'role': role,
+      'localImageDeletion': localImageDeletion,
+    };
+  }
+}

--- a/lib/data/member/repositories/member_repository.dart
+++ b/lib/data/member/repositories/member_repository.dart
@@ -1,3 +1,7 @@
+import 'dart:typed_data';
+
+import 'package:cherrypic/data/member/dto/request/member_edit_profile_request_dto.dart';
+import 'package:cherrypic/data/member/dto/response/member_edit_profile_dto.dart';
 import 'package:cherrypic/data/member/dto/response/member_info_dto.dart';
 
 import '../services/member_remote_data_source.dart';
@@ -15,5 +19,12 @@ class MemberRepository {
     } catch (e) {
       rethrow;
     }
+  }
+
+  /// 회원 정보 수정
+  Future<MemberEditProfileDto> updateProfile(
+      MemberEditProfileRequestDto requestDto,
+      ) async {
+    return await _remoteDataSource.updateProfile(requestDto);
   }
 }

--- a/lib/data/member/repositories/member_repository.dart
+++ b/lib/data/member/repositories/member_repository.dart
@@ -1,0 +1,19 @@
+import 'package:cherrypic/data/member/dto/response/member_info_dto.dart';
+
+import '../services/member_remote_data_source.dart';
+
+class MemberRepository {
+  final MemberRemoteDataSource _remoteDataSource;
+
+  MemberRepository({MemberRemoteDataSource? remoteDataSource})
+      : _remoteDataSource = remoteDataSource ?? MemberRemoteDataSource();
+
+  /// 회원 정보 조회
+  Future<MemberInfoDto> getMemberInfo() async {
+    try {
+      return await _remoteDataSource.getMemberInfo();
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/lib/data/member/repositories/member_repository.dart
+++ b/lib/data/member/repositories/member_repository.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:cherrypic/data/member/dto/request/member_edit_profile_request_dto.dart';
 import 'package:cherrypic/data/member/dto/response/member_edit_profile_dto.dart';
 import 'package:cherrypic/data/member/dto/response/member_info_dto.dart';

--- a/lib/data/member/services/member_remote_data_source.dart
+++ b/lib/data/member/services/member_remote_data_source.dart
@@ -2,8 +2,11 @@ import 'package:cherrypic/core/network/api_path.dart';
 import 'package:cherrypic/core/network/api_response.dart';
 import 'package:cherrypic/core/network/dio_client.dart';
 import 'package:cherrypic/core/network/error_handler.dart';
+import 'package:cherrypic/data/member/dto/request/member_edit_profile_request_dto.dart';
 import 'package:cherrypic/data/member/dto/response/member_info_dto.dart';
 import 'package:dio/dio.dart';
+
+import '../dto/response/member_edit_profile_dto.dart';
 
 class MemberRemoteDataSource {
   final Dio _dio = DioClient().dio;
@@ -20,6 +23,27 @@ class MemberRemoteDataSource {
 
       return apiResponse.data!;
     } on DioException catch (e){
+      throw ErrorHandler.handle(e);
+    }
+  }
+
+  /// 회원 정보 수정
+  Future<MemberEditProfileDto> updateProfile(
+      MemberEditProfileRequestDto requestDto) async {
+    try {
+      final response = await _dio.patch(
+        ApiPath.memberInfo(),
+        data: requestDto.toJson(),
+      );
+
+      final apiResponse = ApiResponse.fromJson(
+        response.data,
+            (json) =>
+            MemberEditProfileDto.fromJson(json as Map<String, dynamic>),
+      );
+
+      return apiResponse.data!;
+    } on DioException catch (e) {
       throw ErrorHandler.handle(e);
     }
   }

--- a/lib/data/member/services/member_remote_data_source.dart
+++ b/lib/data/member/services/member_remote_data_source.dart
@@ -1,0 +1,26 @@
+import 'package:cherrypic/core/network/api_path.dart';
+import 'package:cherrypic/core/network/api_response.dart';
+import 'package:cherrypic/core/network/dio_client.dart';
+import 'package:cherrypic/core/network/error_handler.dart';
+import 'package:cherrypic/data/member/dto/response/member_info_dto.dart';
+import 'package:dio/dio.dart';
+
+class MemberRemoteDataSource {
+  final Dio _dio = DioClient().dio;
+
+  /// 회원 정보 조회
+  Future<MemberInfoDto> getMemberInfo() async {
+    try {
+      final response = await _dio.get(ApiPath.memberInfo());
+
+      final apiResponse = ApiResponse.fromJson(
+        response.data,
+          (json) => MemberInfoDto.fromJson(json as Map<String, dynamic>),
+      );
+
+      return apiResponse.data!;
+    } on DioException catch (e){
+      throw ErrorHandler.handle(e);
+    }
+  }
+}

--- a/lib/data/member/services/profile_image_upload_service.dart
+++ b/lib/data/member/services/profile_image_upload_service.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+import 'package:cherrypic/core/network/dio_client.dart';
+import 'package:cherrypic/core/network/api_response.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+class ProfileImageUploadService {
+  final Dio _dio;
+
+  ProfileImageUploadService({Dio? dio}) : _dio = dio ?? DioClient().dio;
+
+  // 이미지를 업로드하고 URL을 반환
+  Future<String> uploadCoverImage(Uint8List imageData) async {
+    try {
+      // 1. 이미지의 MD5 해시 계산
+      final bytes = imageData;
+      final digest = md5.convert(bytes);
+      final hash = digest.toString();
+
+      // MD5를 Base64로 인코딩 (S3 요구사항)
+      final md5Base64 = base64.encode(digest.bytes);
+
+      // 2. 이미지 확장자 감지
+      final extension = _detectImageExtension(imageData);
+
+      debugPrint('🖼️ 이미지 정보:');
+      debugPrint('  - 크기: ${imageData.length} bytes');
+      debugPrint('  - 첫 12바이트: ${imageData.take(12).toList()}');
+      debugPrint('  - 감지된 확장자: $extension');
+      debugPrint('  - MD5 Hash: $hash');
+      debugPrint('  - MD5 Base64: $md5Base64');
+
+      // 3. Presigned URL 요청
+      final presignedResponse = await _dio.post(
+        '/members/profile-upload-url',
+        data: {'fileExtension': extension, 'md5Hash': md5Base64},
+      );
+
+      final apiResponse = ApiResponse.fromJson(
+        presignedResponse.data,
+            (json) => json as Map<String, dynamic>,
+      );
+
+      final presignedUrl = apiResponse.data!['presignedUrl'] as String;
+      debugPrint('✅ Presigned URL 받기 성공');
+
+      // 4. S3에 이미지 업로드
+      final uploadDio = Dio();
+      await uploadDio.put(
+        presignedUrl,
+        data: bytes,
+        options: Options(
+          headers: {
+            'Content-Type': _getContentType(extension),
+            'Content-MD5': md5Base64,
+          },
+          validateStatus: (status) {
+            debugPrint('📤 S3 업로드 상태: $status');
+            return status != null && status >= 200 && status < 300;
+          },
+        ),
+      );
+
+      debugPrint('✅ S3 업로드 성공');
+
+      // 5. 업로드된 이미지의 공개 URL 반환
+      final uri = Uri.parse(presignedUrl);
+      final publicUrl = '${uri.scheme}://${uri.host}${uri.path}';
+
+      debugPrint('📍 Public URL: $publicUrl');
+      return publicUrl;
+    } catch (e) {
+      debugPrint('❌ 이미지 업로드 실패: $e');
+      throw Exception('이미지 업로드 실패: $e');
+    }
+  }
+
+  // 이미지 데이터의 매직 넘버를 보고 확장자 판단
+  String _detectImageExtension(Uint8List data) {
+    if (data.length < 12) {
+      debugPrint('이미지 크기가 너무 작음: ${data.length} bytes');
+      return 'JPEG';
+    }
+
+    // PNG: 89 50 4E 47
+    if (data[0] == 0x89 &&
+        data[1] == 0x50 &&
+        data[2] == 0x4E &&
+        data[3] == 0x47) {
+      debugPrint('PNG 포맷 감지');
+      return 'PNG';
+    }
+
+    // JPEG: FF D8 FF
+    if (data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF) {
+      debugPrint('JPEG 포맷 감지');
+      return 'JPEG';
+    }
+
+    // WEBP
+    if (data.length >= 12 &&
+        data[0] == 0x52 &&
+        data[1] == 0x49 &&
+        data[2] == 0x46 &&
+        data[3] == 0x46 &&
+        data[8] == 0x57 &&
+        data[9] == 0x45 &&
+        data[10] == 0x42 &&
+        data[11] == 0x50) {
+      debugPrint('WEBP 포맷 감지');
+      return 'WEBP';
+    }
+
+    // HEIC/HEIF
+    if (data.length >= 12 &&
+        data[4] == 0x66 &&
+        data[5] == 0x74 &&
+        data[6] == 0x79 &&
+        data[7] == 0x70) {
+      debugPrint('📦 ftyp 박스 발견');
+
+      if (data.length >= 12 &&
+          ((data[8] == 0x68 &&
+              data[9] == 0x65 &&
+              data[10] == 0x69 &&
+              data[11] == 0x63) ||
+              (data[8] == 0x6D &&
+                  data[9] == 0x69 &&
+                  data[10] == 0x66 &&
+                  data[11] == 0x31))) {
+        debugPrint('HEIC 포맷 감지');
+        return 'HEIC';
+      }
+
+      if (data.length >= 12 &&
+          ((data[8] == 0x68 &&
+              data[9] == 0x65 &&
+              data[10] == 0x69 &&
+              data[11] == 0x66) ||
+              (data[8] == 0x6D &&
+                  data[9] == 0x73 &&
+                  data[10] == 0x66 &&
+                  data[11] == 0x31))) {
+        debugPrint('HEIF 포맷 감지');
+        return 'HEIF';
+      }
+    }
+
+    debugPrint('⚠️ 알 수 없는 포맷, JPEG로 기본 설정');
+    return 'JPEG';
+  }
+
+  // 확장자에 따른 Content-Type 반환
+  String _getContentType(String extension) {
+    switch (extension.toUpperCase()) {
+      case 'PNG':
+        return 'image/png';
+      case 'JPEG':
+      case 'JPG':
+        return 'image/jpeg';
+      case 'WEBP':
+        return 'image/webp';
+      case 'HEIC':
+        return 'image/heic';
+      case 'HEIF':
+        return 'image/heif';
+      default:
+        return 'image/jpeg';
+    }
+  }
+}

--- a/lib/presentation/screens/main/detail/components/album_content_list.dart
+++ b/lib/presentation/screens/main/detail/components/album_content_list.dart
@@ -3,7 +3,6 @@ import 'package:cherrypic/core/router/route_path.dart';
 
 import 'package:cherrypic/core/constants/color.dart';
 import 'package:cherrypic/core/constants/font.dart';
-import 'package:cherrypic/presentation/screens/main/detail/events_tab/%20create/create_event_sheet.dart';
 import 'package:cherrypic/presentation/screens/main/detail/events_tab/components/event_album_cover.dart';
 import 'package:cherrypic/presentation/screens/main/detail/events_tab/event_tab_view_model.dart';
 import 'package:cherrypic/presentation/widgets/album/album_group_section.dart';
@@ -11,6 +10,7 @@ import 'package:cherrypic/presentation/widgets/album/album_group_section.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../album_detail_view_model.dart';
+import '../events_tab/create/create_event_sheet.dart';
 
 class AlbumContentList extends StatelessWidget {
   final int tabIndex;

--- a/lib/presentation/screens/main/detail/events_tab/add/add_images_sheet.dart
+++ b/lib/presentation/screens/main/detail/events_tab/add/add_images_sheet.dart
@@ -1,6 +1,5 @@
 import 'package:cherrypic/core/constants/color.dart';
 import 'package:cherrypic/core/constants/font.dart';
-import 'package:cherrypic/presentation/screens/main/detail/events_tab/%20create/create_event_sort_buttons.dart';
 import 'package:cherrypic/presentation/screens/main/detail/events_tab/add/add_images_sort_buttons.dart';
 import 'package:cherrypic/presentation/screens/main/detail/events_tab/add/add_images_view_model.dart';
 import 'package:cherrypic/presentation/widgets/album/album_group_section.dart';

--- a/lib/presentation/screens/main/detail/events_tab/create/create_event_sheet.dart
+++ b/lib/presentation/screens/main/detail/events_tab/create/create_event_sheet.dart
@@ -1,4 +1,4 @@
-import 'package:cherrypic/presentation/screens/main/detail/events_tab/%20create/create_event_sort_buttons.dart';
+import 'package:cherrypic/presentation/screens/main/detail/events_tab/create/create_event_sort_buttons.dart';
 import 'package:cherrypic/presentation/widgets/album/album_group_section.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';

--- a/lib/presentation/screens/main/detail/events_tab/create/create_event_sort_buttons.dart
+++ b/lib/presentation/screens/main/detail/events_tab/create/create_event_sort_buttons.dart
@@ -1,4 +1,4 @@
-import 'package:cherrypic/presentation/screens/main/detail/events_tab/%20create/create_event_view_model.dart';
+import 'package:cherrypic/presentation/screens/main/detail/events_tab/create/create_event_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/presentation/screens/my_page/album_management/album_management_screen.dart
+++ b/lib/presentation/screens/my_page/album_management/album_management_screen.dart
@@ -67,7 +67,7 @@ class _AlbumManagementScreenState extends State<AlbumManagementScreen> {
                   children: [
                     _buildSubscriptionList(viewModel.displayedItems),
 
-                    if (viewModel.displayedItems.length > 3)
+                    if (viewModel.displayedItems.length > 5)
                       GestureDetector(
                         onTap: viewModel.toggleExpand,
                         child: Row(

--- a/lib/presentation/screens/my_page/album_management/album_management_screen.dart
+++ b/lib/presentation/screens/my_page/album_management/album_management_screen.dart
@@ -114,7 +114,12 @@ class _AlbumManagementScreenState extends State<AlbumManagementScreen> {
             model: item,
             showDates: false,
             onTap: () {
-              context.push(RoutePath.myPage_payment_info, extra: item);
+              final path = '${RoutePath.myPage_payment_info}?albumId=${item.albumId}';
+
+              context.push(
+                path,
+                extra: item,
+              );
             },
           ),
         );

--- a/lib/presentation/screens/my_page/album_management/album_management_view_model.dart
+++ b/lib/presentation/screens/my_page/album_management/album_management_view_model.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../../../data/album/dto/response/album_dto.dart';
+import '../../../../data/album/repositories/album_repository.dart';
 import '../../../widgets/album/album_badge_type.dart';
 import '../album_payment_info/album_payment_info_model.dart';
 import '../album_payment_info/album_payment_info_view_model.dart';
@@ -6,56 +9,13 @@ import '../album_payment_info/album_payment_info_view_model.dart';
 enum PaymentStatusType { using, pending }
 
 class AlbumManagementViewModel extends ChangeNotifier {
-  final List<AlbumPaymentInfoModel> allItems = const [
-    AlbumPaymentInfoModel(
-      albumId: 1,
-      badgeType: AlbumBadgeType.basic,
-      title: '음식(양식, 중식, 한식, 일식) 음식 음식',
-      createDate: '2025/06/23',
-      price: '무료',
-      status: PaymentStatusType.using,
-    ),
-    AlbumPaymentInfoModel(
-      albumId: 2,
-      badgeType: AlbumBadgeType.pro,
-      title: '프랑스 여행_2025.06.24',
-      createDate: '2025/06/23',
-      startDate: '2025/05/25',
-      nextDate: '2025/08/25',
-      price: '월 3,900원',
-      status: PaymentStatusType.using,
-    ),
-    AlbumPaymentInfoModel(
-      albumId: 3,
-      badgeType: AlbumBadgeType.premium,
-      title: '프랑스 여행_2025.06.24',
-      createDate: '2025/06/23',
-      startDate: '2025/05/25',
-      nextDate: '2025/08/25',
-      price: '월 3,900원',
-      status: PaymentStatusType.using,
-    ),
-    AlbumPaymentInfoModel(
-      albumId: 4,
-      badgeType: AlbumBadgeType.pro,
-      title: '호주 여행',
-      createDate: '2025/06/23',
-      startDate: '2025/06/28',
-      nextDate: '2025/08/25',
-      price: '월 5,900원',
-      status: PaymentStatusType.pending,
-    ),
-    AlbumPaymentInfoModel(
-      albumId: 5,
-      badgeType: AlbumBadgeType.premium,
-      title: '호주 여행',
-      createDate: '2025/06/23',
-      startDate: '2025/06/28',
-      nextDate: '2025/08/25',
-      price: '월 5,900원',
-      status: PaymentStatusType.pending,
-    ),
-  ];
+  List<AlbumPaymentInfoModel> _allAlbums = [];
+  List<AlbumPaymentInfoModel> get allItems => _allAlbums;
+
+  final AlbumRepository _repository;
+
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
 
   PaymentStatusType _selectedStatus = PaymentStatusType.using;
   PaymentStatusType get selectedStatus => _selectedStatus;
@@ -66,8 +26,97 @@ class AlbumManagementViewModel extends ChangeNotifier {
   bool _isExpanded = false;
   bool get isExpanded => _isExpanded;
 
-  AlbumManagementViewModel() {
-    _ensureSelectedBadge();
+  AlbumManagementViewModel({AlbumRepository? repository})
+      : _repository = repository ?? AlbumRepository() {
+    fetchAlbums();
+  }
+
+  PaymentStatusType _mapSubscriptionStatus(String? dtoStatus) {
+    if (dtoStatus == null) return PaymentStatusType.pending;
+    switch (dtoStatus.toUpperCase()) {
+      case 'ACTIVE':
+        return PaymentStatusType.using;
+      case 'CANCELED':
+      case 'EXPIRED':
+        return PaymentStatusType.pending;
+      default:
+        return PaymentStatusType.pending;
+    }
+  }
+
+  Future<AlbumPaymentInfoModel> _mapDtoToModel(AlbumDto dto) async {
+    AlbumBadgeType badgeType = switch (dto.type.toUpperCase()) {
+      'PRO' => AlbumBadgeType.pro,
+      'PREMIUM' => AlbumBadgeType.premium,
+      _ => AlbumBadgeType.basic,
+    };
+
+    final priceFormatter = NumberFormat.currency(locale: 'ko_KR', symbol: '원', decimalDigits: 0);
+    final priceFormatted = priceFormatter.format(dto.price);
+    final String price = badgeType == AlbumBadgeType.basic ? '무료' : '월 $priceFormatted';
+
+    final String formattedCreateDate = dto.createdAt.split('T').first.replaceAll('-', '/');
+
+    String? startDate;
+    String? nextDate;
+    PaymentStatusType status = PaymentStatusType.using;
+
+    if (badgeType != AlbumBadgeType.basic) {
+      status = _mapSubscriptionStatus(dto.status);
+
+      try {
+        final subscriptionInfo = await _repository.getAlbumSubscriptionInfo(dto.albumId);
+
+        startDate = subscriptionInfo.subscriptionStartAt.split('T').first.replaceAll('-', '/');
+        nextDate = subscriptionInfo.subscriptionNextBillingAt.split('T').first.replaceAll('-', '/');
+
+      } catch (e) {
+        debugPrint('Error fetching subscription info for album ${dto.albumId}: $e');
+      }
+    }
+
+    return AlbumPaymentInfoModel(
+      albumId: dto.albumId,
+      badgeType: badgeType,
+      title: dto.title,
+      createDate: formattedCreateDate,
+      startDate: startDate,
+      nextDate: nextDate,
+      price: price,
+      status: status,
+    );
+  }
+
+  /// 앨범 목록 및 구독 정보를 비동기로 가져오는 메인 함수
+  Future<void> fetchAlbums() async {
+    if (_isLoading) return;
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      final Future<AlbumListResponseDto> basicFuture = _repository.getAlbums(type: 'BASIC');
+      final Future<AlbumListResponseDto> proFuture = _repository.getAlbums(type: 'PRO');
+      final Future<AlbumListResponseDto> premiumFuture = _repository.getAlbums(type: 'PREMIUM');
+
+      final List<AlbumListResponseDto> responses = await Future.wait([basicFuture, proFuture, premiumFuture]);
+
+      final List<AlbumDto> allDtos = [
+        ...responses[0].albums,
+        ...responses[1].albums,
+        ...responses[2].albums,
+      ];
+
+      _allAlbums = await Future.wait(allDtos.map(_mapDtoToModel));
+
+      _ensureSelectedBadge();
+
+    } catch (e) {
+      debugPrint('Error during fetchAlbums in AlbumManagementViewModel: $e');
+      _allAlbums = [];
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
   }
 
   List<AlbumBadgeType> get availableBadges {
@@ -75,31 +124,36 @@ class AlbumManagementViewModel extends ChangeNotifier {
       return [AlbumBadgeType.pro, AlbumBadgeType.premium];
     }
 
-    final set = <AlbumBadgeType>{};
-    for (final item in allItems) {
-      if (item.status == _selectedStatus) {
-        set.add(item.badgeType);
-      }
-    }
-    const order = [
+    return [
       AlbumBadgeType.basic,
       AlbumBadgeType.pro,
       AlbumBadgeType.premium
     ];
-    return order.where(set.contains).toList();
   }
 
   List<AlbumPaymentInfoModel> get displayedItems {
-    var filtered = allItems.where((e) => e.status == _selectedStatus).toList();
+    var filtered = _allAlbums.where((e) => e.status == _selectedStatus).toList();
 
-    if (availableBadges.contains(_selectedBadge)) {
-      filtered = filtered.where((e) => e.badgeType == _selectedBadge).toList();
-    }
+    filtered = filtered.where((e) => e.badgeType == _selectedBadge).toList();
 
     if (!_isExpanded && filtered.length > 5) {
       return filtered.take(5).toList();
     }
     return filtered;
+  }
+
+  void _ensureSelectedBadge() {
+    final avail = availableBadges;
+
+    if (_selectedStatus == PaymentStatusType.using) {
+      if (!avail.contains(_selectedBadge)) {
+        _selectedBadge = AlbumBadgeType.basic;
+      }
+    } else if (_selectedStatus == PaymentStatusType.pending) {
+      if (!avail.contains(_selectedBadge)) {
+        _selectedBadge = AlbumBadgeType.pro;
+      }
+    }
   }
 
   void changeStatus(PaymentStatusType status) {
@@ -142,14 +196,6 @@ class AlbumManagementViewModel extends ChangeNotifier {
         return PaymentStatusType.using;
       case AlbumFilterType.premium:
         return PaymentStatusType.pending;
-    }
-  }
-
-  void _ensureSelectedBadge() {
-    final avail = availableBadges;
-    if (avail.isEmpty) return;
-    if (!avail.contains(_selectedBadge)) {
-      _selectedBadge = avail.first;
     }
   }
 }

--- a/lib/presentation/screens/my_page/album_management/album_management_view_model.dart
+++ b/lib/presentation/screens/my_page/album_management/album_management_view_model.dart
@@ -8,6 +8,7 @@ enum PaymentStatusType { using, pending }
 class AlbumManagementViewModel extends ChangeNotifier {
   final List<AlbumPaymentInfoModel> allItems = const [
     AlbumPaymentInfoModel(
+      albumId: 1,
       badgeType: AlbumBadgeType.basic,
       title: '음식(양식, 중식, 한식, 일식) 음식 음식',
       createDate: '2025/06/23',
@@ -15,6 +16,7 @@ class AlbumManagementViewModel extends ChangeNotifier {
       status: PaymentStatusType.using,
     ),
     AlbumPaymentInfoModel(
+      albumId: 2,
       badgeType: AlbumBadgeType.pro,
       title: '프랑스 여행_2025.06.24',
       createDate: '2025/06/23',
@@ -24,6 +26,7 @@ class AlbumManagementViewModel extends ChangeNotifier {
       status: PaymentStatusType.using,
     ),
     AlbumPaymentInfoModel(
+      albumId: 3,
       badgeType: AlbumBadgeType.premium,
       title: '프랑스 여행_2025.06.24',
       createDate: '2025/06/23',
@@ -33,6 +36,7 @@ class AlbumManagementViewModel extends ChangeNotifier {
       status: PaymentStatusType.using,
     ),
     AlbumPaymentInfoModel(
+      albumId: 4,
       badgeType: AlbumBadgeType.pro,
       title: '호주 여행',
       createDate: '2025/06/23',
@@ -42,6 +46,7 @@ class AlbumManagementViewModel extends ChangeNotifier {
       status: PaymentStatusType.pending,
     ),
     AlbumPaymentInfoModel(
+      albumId: 5,
       badgeType: AlbumBadgeType.premium,
       title: '호주 여행',
       createDate: '2025/06/23',

--- a/lib/presentation/screens/my_page/album_payment_info/album_payment_info_model.dart
+++ b/lib/presentation/screens/my_page/album_payment_info/album_payment_info_model.dart
@@ -2,6 +2,7 @@ import '../../../widgets/album/album_badge_type.dart';
 import '../album_management/album_management_view_model.dart';
 
 class AlbumPaymentInfoModel {
+  final int albumId;
   final AlbumBadgeType badgeType;
   final String title;
   final String createDate;
@@ -12,6 +13,7 @@ class AlbumPaymentInfoModel {
 
 
   const AlbumPaymentInfoModel({
+    required this.albumId,
     required this.badgeType,
     required this.title,
     required this.createDate,

--- a/lib/presentation/screens/my_page/album_payment_info/album_payment_info_screen.dart
+++ b/lib/presentation/screens/my_page/album_payment_info/album_payment_info_screen.dart
@@ -125,8 +125,10 @@ class _AlbumPaymentInfoScreenState extends State<AlbumPaymentInfoScreen> {
           child: PaymentBox(
             model: item,
             onTap: () {
+              final path = '${RoutePath.myPage_payment_info}?albumId=${item.albumId}';
+
               context.push(
-                RoutePath.myPage_payment_info,
+                path,
                 extra: item,
               );
             },

--- a/lib/presentation/screens/my_page/album_payment_info/album_payment_info_screen.dart
+++ b/lib/presentation/screens/my_page/album_payment_info/album_payment_info_screen.dart
@@ -40,6 +40,8 @@ class _AlbumPaymentInfoScreenState extends State<AlbumPaymentInfoScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final filteredItems = viewModel.filteredItems;
+
     return Scaffold(
       appBar: const CustomSubAppBar(title: '앨범 결제정보'),
       backgroundColor: Colors.white,
@@ -49,45 +51,47 @@ class _AlbumPaymentInfoScreenState extends State<AlbumPaymentInfoScreen> {
             child: SingleChildScrollView(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 30),
-                child: Column(
-                  children: [
-                    const SizedBox(height: 28),
+                child: Center(
+                  child: Column(
+                    children: [
+                      const SizedBox(height: 28),
 
-                    // pro/premium 토글
-                    TypeToggle(
-                      selected: viewModel.selectedFilter,
-                      onChanged: (type) => viewModel.changeFilter(type),
-                    ),
-
-                    const SizedBox(height: 35),
-
-                    _buildSubscriptionList(viewModel.displayedItems),
-
-                    if (viewModel.shouldShowToggle)
-                      GestureDetector(
-                        onTap: viewModel.toggleExpand,
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              viewModel.isExpanded ? '접기' : '전체 보기',
-                              style: AppFont.size16.copyWith(
-                                color: AppColor.mainRed,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            const SizedBox(width: 10),
-                            Icon(
-                              viewModel.isExpanded
-                                  ? Icons.arrow_drop_up
-                                  : Icons.arrow_drop_down,
-                              color: AppColor.mainRed,
-                            ),
-                          ],
-                        ),
+                      // pro/premium 토글
+                      TypeToggle(
+                        selected: viewModel.selectedFilter,
+                        onChanged: (type) => viewModel.onToggleType(type),
                       ),
-                    const SizedBox(height: 30),
-                  ],
+
+                      const SizedBox(height: 35),
+
+                      _buildSubscriptionList(filteredItems),
+
+                      if (viewModel.shouldShowToggle)
+                        GestureDetector(
+                          onTap: viewModel.toggleExpansion,
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                viewModel.isExpanded ? '접기' : '전체 보기',
+                                style: AppFont.size16.copyWith(
+                                  color: AppColor.mainRed,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              const SizedBox(width: 10),
+                              Icon(
+                                viewModel.isExpanded
+                                    ? Icons.arrow_drop_up
+                                    : Icons.arrow_drop_down,
+                                color: AppColor.mainRed,
+                              ),
+                            ],
+                          ),
+                        ),
+                      const SizedBox(height: 30),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -99,6 +103,17 @@ class _AlbumPaymentInfoScreenState extends State<AlbumPaymentInfoScreen> {
 
   /// 리스트 빌더
   Widget _buildSubscriptionList(List<AlbumPaymentInfoModel> items) {
+    // 항목이 없을 경우 처리
+    if (items.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 50),
+        child: Text(
+          '결제 정보가 없습니다.',
+          style: AppFont.size16.copyWith(color: Colors.grey),
+        ),
+      );
+    }
+
     return ListView.builder(
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
@@ -109,7 +124,6 @@ class _AlbumPaymentInfoScreenState extends State<AlbumPaymentInfoScreen> {
           padding: EdgeInsets.only(bottom: index == items.length - 1 ? 0 : 30),
           child: PaymentBox(
             model: item,
-            showDates: false,
             onTap: () {
               context.push(
                 RoutePath.myPage_payment_info,

--- a/lib/presentation/screens/my_page/album_payment_info/album_payment_info_view_model.dart
+++ b/lib/presentation/screens/my_page/album_payment_info/album_payment_info_view_model.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../../../data/album/dto/response/album_dto.dart';
+import '../../../../data/album/repositories/album_repository.dart';
 import '../../../widgets/album/album_badge_type.dart';
+
 import 'album_payment_info_model.dart';
+
 
 /// Pro / Premium 타입
 enum AlbumFilterType {
@@ -9,49 +14,18 @@ enum AlbumFilterType {
 }
 
 class AlbumPaymentInfoViewModel extends ChangeNotifier {
-  /// 전체 항목 리스트
-  final List<AlbumPaymentInfoModel> allItems = const [
-    AlbumPaymentInfoModel(
-      badgeType: AlbumBadgeType.pro,
-      title: '프랑스 여행_2025. 06. 24',
-      createDate: '2025/06/23',
-      startDate: '2025/05/25',
-      nextDate: '2025/08/25',
-      price: '월 3,900원',
-    ),
-    AlbumPaymentInfoModel(
-      badgeType: AlbumBadgeType.premium,
-      title: '호주 여행',
-      createDate: '2025/06/23',
-      startDate: '2025/06/28',
-      nextDate: '2025/08/25',
-      price: '월 5,900원',
-    ),
-    AlbumPaymentInfoModel(
-      badgeType: AlbumBadgeType.pro,
-      title: '등반',
-      createDate: '2025/06/23',
-      startDate: '2025/07/01',
-      nextDate: '2025/09/01',
-      price: '월 3,900원',
-    ),
-    AlbumPaymentInfoModel(
-      badgeType: AlbumBadgeType.premium,
-      title: '호주 여행',
-      createDate: '2025/06/23',
-      startDate: '2025/06/28',
-      nextDate: '2025/08/25',
-      price: '월 5,900원',
-    ),
-    AlbumPaymentInfoModel(
-      badgeType: AlbumBadgeType.pro,
-      title: '프랑스 여행_2025. 06. 24',
-      createDate: '2025/06/23',
-      startDate: '2025/05/25',
-      nextDate: '2025/08/25',
-      price: '월 3,900원',
-    ),
-  ];
+  // ✨ [추가] AlbumRepository 주입
+  final AlbumRepository _albumRepository;
+
+  AlbumPaymentInfoViewModel({AlbumRepository? albumRepository})
+      : _albumRepository = albumRepository ?? AlbumRepository() {
+    // ViewModel 생성 시점에 데이터 로딩 시작
+    fetchAlbums();
+  }
+
+  // ✨ [수정] API에서 받아온 PRO/PREMIUM 앨범 목록을 저장할 상태 변수
+  List<AlbumDto> _proAlbums = [];
+  List<AlbumDto> _premiumAlbums = [];
 
   /// 전체 보기 여부
   bool _isExpanded = false;
@@ -61,32 +35,81 @@ class AlbumPaymentInfoViewModel extends ChangeNotifier {
   AlbumFilterType _selectedFilter = AlbumFilterType.pro;
   AlbumFilterType get selectedFilter => _selectedFilter;
 
-  /// 전체 항목 개수 기준 토글 표시 여부
-  bool get shouldShowToggle => allItems.length > 5;
+  Future<void> fetchAlbums() async {
+    try {
+      // PRO 앨범 목록 조회
+      final proResponse = await _albumRepository.getAlbums(type: 'PRO');
+      _proAlbums = proResponse.albums;
 
-  /// 현재 선택된 토글(Pro/Premium)에 맞게 필터링된 항목
-  List<AlbumPaymentInfoModel> get displayedItems {
-    final filtered = allItems.where((item) {
-      if (_selectedFilter == AlbumFilterType.pro) {
-        return item.badgeType == AlbumBadgeType.pro;
-      } else {
-        return item.badgeType == AlbumBadgeType.premium;
-      }
-    }).toList();
+      // PREMIUM 앨범 목록 조회
+      final premiumResponse = await _albumRepository.getAlbums(type: 'PREMIUM');
+      _premiumAlbums = premiumResponse.albums;
 
-    return _isExpanded ? filtered : filtered.take(5).toList();
+    } catch (e) {
+      debugPrint('Error fetching albums: $e');
+      // 에러 처리 로직
+    } finally {
+      notifyListeners();
+    }
   }
 
-  /// 전체 보기 토글
-  void toggleExpand() {
-    _isExpanded = !_isExpanded;
-    notifyListeners();
+  /// 전체 항목 개수 기준 토글 표시 여부
+  bool get shouldShowToggle {
+    final bool proExceeds = _proAlbums.length > 5;
+
+    final bool premiumExceeds = _premiumAlbums.length > 5;
+
+    return proExceeds || premiumExceeds;
+  }
+
+  List<AlbumPaymentInfoModel> get filteredItems {
+    final List<AlbumDto> albums = _selectedFilter == AlbumFilterType.pro
+        ? _proAlbums
+        : _premiumAlbums;
+
+    final List<AlbumDto> displayAlbums = _isExpanded || albums.length <= 5
+        ? albums
+        : albums.take(5).toList();
+
+    return displayAlbums.map((dto) {
+      AlbumBadgeType badgeType;
+      if (dto.type.toUpperCase() == 'PRO') {
+        badgeType = AlbumBadgeType.pro;
+      } else if (dto.type.toUpperCase() == 'PREMIUM') {
+        badgeType = AlbumBadgeType.premium;
+      } else {
+        badgeType = AlbumBadgeType.none;
+      }
+
+      final priceFormatted = NumberFormat.currency(
+          locale: 'ko_KR',
+          symbol: '원',
+          decimalDigits: 0
+      ).format(dto.price);
+
+      String formattedCreateDate = dto.createdAt.split('T').first.replaceAll('-', '/');
+
+      return AlbumPaymentInfoModel(
+        badgeType: badgeType,
+        title: dto.title,
+        createDate: formattedCreateDate,
+        price: '월 $priceFormatted',
+      );
+    }).toList();
   }
 
   /// 필터 변경
-  void changeFilter(AlbumFilterType type) {
-    _selectedFilter = type;
-    _isExpanded = false;
+  void onToggleType(AlbumFilterType type) {
+    if (_selectedFilter != type) {
+      _selectedFilter = type;
+      _isExpanded = false;
+      notifyListeners();
+    }
+  }
+
+  /// 전체 보기 토글
+  void toggleExpansion() {
+    _isExpanded = !_isExpanded;
     notifyListeners();
   }
 }

--- a/lib/presentation/screens/my_page/album_payment_info/album_payment_info_view_model.dart
+++ b/lib/presentation/screens/my_page/album_payment_info/album_payment_info_view_model.dart
@@ -6,7 +6,6 @@ import '../../../widgets/album/album_badge_type.dart';
 
 import 'album_payment_info_model.dart';
 
-
 /// Pro / Premium 타입
 enum AlbumFilterType {
   pro,
@@ -14,55 +13,51 @@ enum AlbumFilterType {
 }
 
 class AlbumPaymentInfoViewModel extends ChangeNotifier {
-  // ✨ [추가] AlbumRepository 주입
   final AlbumRepository _albumRepository;
 
   AlbumPaymentInfoViewModel({AlbumRepository? albumRepository})
       : _albumRepository = albumRepository ?? AlbumRepository() {
-    // ViewModel 생성 시점에 데이터 로딩 시작
     fetchAlbums();
   }
 
-  // ✨ [수정] API에서 받아온 PRO/PREMIUM 앨범 목록을 저장할 상태 변수
   List<AlbumDto> _proAlbums = [];
   List<AlbumDto> _premiumAlbums = [];
+
+  List<AlbumPaymentInfoModel> _paymentInfoModels = [];
+  List<AlbumPaymentInfoModel> get filteredItems => _paymentInfoModels;
 
   /// 전체 보기 여부
   bool _isExpanded = false;
   bool get isExpanded => _isExpanded;
+
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
 
   /// 현재 선택된 필터 (기본값: Pro)
   AlbumFilterType _selectedFilter = AlbumFilterType.pro;
   AlbumFilterType get selectedFilter => _selectedFilter;
 
   Future<void> fetchAlbums() async {
+    _isLoading = true;
+    notifyListeners();
     try {
-      // PRO 앨범 목록 조회
       final proResponse = await _albumRepository.getAlbums(type: 'PRO');
       _proAlbums = proResponse.albums;
 
-      // PREMIUM 앨범 목록 조회
       final premiumResponse = await _albumRepository.getAlbums(type: 'PREMIUM');
       _premiumAlbums = premiumResponse.albums;
 
+      await _loadFilteredItems();
+
     } catch (e) {
       debugPrint('Error fetching albums: $e');
-      // 에러 처리 로직
     } finally {
+      _isLoading = false;
       notifyListeners();
     }
   }
 
-  /// 전체 항목 개수 기준 토글 표시 여부
-  bool get shouldShowToggle {
-    final bool proExceeds = _proAlbums.length > 5;
-
-    final bool premiumExceeds = _premiumAlbums.length > 5;
-
-    return proExceeds || premiumExceeds;
-  }
-
-  List<AlbumPaymentInfoModel> get filteredItems {
+  Future<void> _loadFilteredItems() async {
     final List<AlbumDto> albums = _selectedFilter == AlbumFilterType.pro
         ? _proAlbums
         : _premiumAlbums;
@@ -71,7 +66,7 @@ class AlbumPaymentInfoViewModel extends ChangeNotifier {
         ? albums
         : albums.take(5).toList();
 
-    return displayAlbums.map((dto) {
+    fetchAndMap(dto) async {
       AlbumBadgeType badgeType;
       if (dto.type.toUpperCase() == 'PRO') {
         badgeType = AlbumBadgeType.pro;
@@ -87,30 +82,74 @@ class AlbumPaymentInfoViewModel extends ChangeNotifier {
           decimalDigits: 0
       ).format(dto.price);
 
-      String formattedCreateDate = dto.createdAt.split('T').first.replaceAll('-', '/');
+      final String formattedCreateDate = dto.createdAt.split('T').first.replaceAll('-', '/');
 
+      String? startDate;
+      String? nextDate;
+
+      if (dto.type.toUpperCase() == 'PRO' || dto.type.toUpperCase() == 'PREMIUM') {
+        try {
+          final subscriptionInfo = await _albumRepository.getAlbumSubscriptionInfo(dto.albumId);
+
+          startDate = subscriptionInfo.subscriptionStartAt.split('T').first.replaceAll('-', '/');
+
+          nextDate = subscriptionInfo.subscriptionNextBillingAt.split('T').first.replaceAll('-', '/');
+
+        } catch (e) {
+          debugPrint('Error fetching subscription info for album ${dto.albumId}: $e');
+        }
+      }
+
+      // 3. 최종 모델 생성
       return AlbumPaymentInfoModel(
         albumId: dto.albumId,
         badgeType: badgeType,
         title: dto.title,
         createDate: formattedCreateDate,
+        startDate: startDate,
+        nextDate: nextDate,
         price: '월 $priceFormatted',
+        status: null,
       );
-    }).toList();
+    }
+
+    _paymentInfoModels = await Future.wait(displayAlbums.map(fetchAndMap));
+
+    notifyListeners();
+  }
+
+
+  /// 전체 항목 개수 기준 토글 표시 여부
+  bool get shouldShowToggle {
+    final bool proExceeds = _proAlbums.length > 5;
+    final bool premiumExceeds = _premiumAlbums.length > 5;
+    return proExceeds || premiumExceeds;
   }
 
   /// 필터 변경
-  void onToggleType(AlbumFilterType type) {
+  void onToggleType(AlbumFilterType type) async {
     if (_selectedFilter != type) {
       _selectedFilter = type;
       _isExpanded = false;
+      _isLoading = true;
+      notifyListeners();
+
+      await _loadFilteredItems();
+
+      _isLoading = false;
       notifyListeners();
     }
   }
 
   /// 전체 보기 토글
-  void toggleExpansion() {
+  void toggleExpansion() async {
     _isExpanded = !_isExpanded;
+    _isLoading = true;
+    notifyListeners();
+
+    await _loadFilteredItems();
+
+    _isLoading = false;
     notifyListeners();
   }
 }

--- a/lib/presentation/screens/my_page/album_payment_info/album_payment_info_view_model.dart
+++ b/lib/presentation/screens/my_page/album_payment_info/album_payment_info_view_model.dart
@@ -90,6 +90,7 @@ class AlbumPaymentInfoViewModel extends ChangeNotifier {
       String formattedCreateDate = dto.createdAt.split('T').first.replaceAll('-', '/');
 
       return AlbumPaymentInfoModel(
+        albumId: dto.albumId,
         badgeType: badgeType,
         title: dto.title,
         createDate: formattedCreateDate,

--- a/lib/presentation/screens/my_page/album_payment_info/info/payment_info_screen.dart
+++ b/lib/presentation/screens/my_page/album_payment_info/info/payment_info_screen.dart
@@ -12,8 +12,9 @@ import '../album_payment_info_model.dart';
 class PaymentInfoScreen extends StatelessWidget {
   final AlbumPaymentInfoModel item;
   final PaymentInfoViewModel viewModel;
+  final int albumId;
 
-  const PaymentInfoScreen({super.key, required this.item, required this.viewModel});
+  const PaymentInfoScreen({super.key, required this.item, required this.viewModel, required this.albumId});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/screens/my_page/album_payment_info/info/payment_info_view_model.dart
+++ b/lib/presentation/screens/my_page/album_payment_info/info/payment_info_view_model.dart
@@ -1,15 +1,59 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../../../../data/album/repositories/album_repository.dart';
 import 'payment_info_model.dart';
 
 class PaymentInfoViewModel extends ChangeNotifier {
-  /// 전체 결제 내역 리스트 (더미 데이터)
-  final List<PaymentInfoModel> _allPayments = const [
-    PaymentInfoModel(date: "2025/08/01", amount: "-3,900 원"),
-    PaymentInfoModel(date: "2025/07/01", amount: "-3,900 원"),
-    PaymentInfoModel(date: "2025/06/01", amount: "-3,900 원"),
-  ];
+  final AlbumRepository _repository;
+
+  List<PaymentInfoModel> _payments = [];
+
+  final NumberFormat _currencyFormatter = NumberFormat.decimalPattern('ko_KR');
+
+  PaymentInfoViewModel({AlbumRepository? repository})
+      : _repository = repository ?? AlbumRepository();
 
   List<PaymentInfoModel> get payments {
-    return List.unmodifiable(_allPayments);
+    return List.unmodifiable(_payments);
+  }
+
+  Future<void> loadPayments(int albumId) async {
+    try {
+      final response = await _repository.getAlbumPaymentInfo(albumId: albumId);
+
+      _payments = response.content.map((dto) {
+        final dateString = _formatDate(dto.paidAt);
+
+        final formattedAmount = _formatAmountToCurrency(dto.amount);
+
+        return PaymentInfoModel(
+          date: dateString,
+          amount: formattedAmount,
+        );
+      }).toList();
+
+      notifyListeners();
+    } catch (e) {
+      // 에러 처리 로직 추가
+      debugPrint('결제 내역 로딩 에러: $e');
+    }
+  }
+
+  String _formatAmountToCurrency(int amount) {
+    final negativeAmount = -amount;
+
+    final formatted = _currencyFormatter.format(negativeAmount);
+
+    return '$formatted 원';
+  }
+
+  String _formatDate(String paidAt) {
+    try {
+      final dateTime = DateTime.parse(paidAt);
+      return DateFormat('yyyy/MM/dd').format(dateTime);
+    } catch (e) {
+      // 파싱 실패 시 원본 문자열 반환
+      return paidAt;
+    }
   }
 }

--- a/lib/presentation/screens/my_page/my_page_screen.dart
+++ b/lib/presentation/screens/my_page/my_page_screen.dart
@@ -1,4 +1,3 @@
-// my_page_screen.dart
 import 'package:cherrypic/core/constants/color.dart';
 import 'package:cherrypic/presentation/screens/my_page/my_page_view_model.dart';
 import 'package:flutter/material.dart';
@@ -132,14 +131,11 @@ class _MyPageScreenState extends State<MyPageScreen> {
                   // 프로필 사진 수정 버튼
                   GestureDetector(
                     onTap: () async {
-                      // 1. 이미지 선택
-                      await viewModel.pickImage(context);
+                      await viewModel.pickAndSetProfileImage(context);
 
-                      // 2. 이미지가 성공적으로 선택되었다면 프로필 수정 API 호출
                       if (viewModel.coverImage != null) {
                         final success = await viewModel.updateProfile(
                           newCoverImage: viewModel.coverImage,
-                          // 프로필 사진 수정 시에도 기존 닉네임을 request에 전달해야 함
                           newNickname: viewModel.memberInfo?.nickname,
                         );
 

--- a/lib/presentation/screens/my_page/my_page_screen.dart
+++ b/lib/presentation/screens/my_page/my_page_screen.dart
@@ -22,6 +22,8 @@ class _MyPageScreenState extends State<MyPageScreen> {
   void initState() {
     super.initState();
     viewModel = MyPageViewModel();
+    // 화면 초기화 시 회원 정보 조회 API 호출
+    viewModel.fetchMemberInfo();
   }
 
   @override
@@ -31,6 +33,9 @@ class _MyPageScreenState extends State<MyPageScreen> {
       body: AnimatedBuilder(
         animation: viewModel,
         builder: (context, _) {
+          // 회원 정보 가져오기
+          final memberInfo = viewModel.memberInfo;
+
           return SingleChildScrollView(
             child: Align(
               alignment: Alignment.topCenter,
@@ -45,6 +50,19 @@ class _MyPageScreenState extends State<MyPageScreen> {
                       width: 120,
                       height: 120,
                       fit: BoxFit.cover,
+                    )
+                        : (memberInfo?.profileImageUrl != null && memberInfo!.profileImageUrl.isNotEmpty)
+                        ? Image.network(
+                      memberInfo.profileImageUrl,
+                      width: 120,
+                      height: 120,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) => Image.asset(
+                        'assets/images/sample_photo.png',
+                        width: 120,
+                        height: 120,
+                        fit: BoxFit.cover,
+                      ),
                     )
                         : Image.asset(
                       'assets/images/sample_photo.png',
@@ -83,7 +101,8 @@ class _MyPageScreenState extends State<MyPageScreen> {
                         padding: const EdgeInsets.only(left: 30, right: 20),
                         child: HorizontalLabeledTextField(
                             title: '닉네임',
-                            hintText: '홍길동',
+                            // 조회된 닉네임 적용
+                            hintText: memberInfo?.nickname ?? '닉네임을 불러오는 중...',
                             showEditIcon: true
                         ),
                       ),

--- a/lib/presentation/screens/my_page/my_page_screen.dart
+++ b/lib/presentation/screens/my_page/my_page_screen.dart
@@ -1,3 +1,4 @@
+// my_page_screen.dart
 import 'package:cherrypic/core/constants/color.dart';
 import 'package:cherrypic/presentation/screens/my_page/my_page_view_model.dart';
 import 'package:flutter/material.dart';
@@ -17,6 +18,7 @@ class MyPageScreen extends StatefulWidget {
 
 class _MyPageScreenState extends State<MyPageScreen> {
   late final MyPageViewModel viewModel;
+  late final TextEditingController _nicknameController; // 닉네임 입력을 위한 컨트롤러 추가
 
   @override
   void initState() {
@@ -24,6 +26,62 @@ class _MyPageScreenState extends State<MyPageScreen> {
     viewModel = MyPageViewModel();
     // 화면 초기화 시 회원 정보 조회 API 호출
     viewModel.fetchMemberInfo();
+    _nicknameController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _nicknameController.dispose();
+    super.dispose();
+  }
+
+  // 닉네임 수정을 처리하는 다이얼로그 함수
+  void _editNickname(BuildContext context) {
+    // 현재 닉네임을 컨트롤러에 설정
+    _nicknameController.text = viewModel.memberInfo?.nickname ?? '';
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('닉네임 수정'),
+          content: TextField(
+            controller: _nicknameController,
+            decoration: const InputDecoration(hintText: "새 닉네임을 입력하세요"),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('취소'),
+            ),
+            TextButton(
+              onPressed: () async {
+                final newNickname = _nicknameController.text.trim();
+                final currentNickname = viewModel.memberInfo?.nickname;
+
+                if (newNickname.isNotEmpty && newNickname != currentNickname) {
+                  Navigator.pop(context);
+                  // 닉네임 수정 API 호출 (새 닉네임과 기존 이미지 URL 전달)
+                  final success = await viewModel.updateProfile(newNickname: newNickname);
+
+                  if (success) {
+                    // 성공 피드백 (추가 구현 필요)
+                    if (mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('닉네임이 성공적으로 수정되었습니다.')));
+                  } else {
+                    // 실패 피드백 (추가 구현 필요)
+                    if (mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('닉네임 수정에 실패했습니다.')));
+                  }
+                } else {
+                  // 변경 사항이 없거나 유효하지 않은 경우
+                  Navigator.pop(context);
+                }
+              },
+              child: const Text('저장'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
@@ -33,7 +91,6 @@ class _MyPageScreenState extends State<MyPageScreen> {
       body: AnimatedBuilder(
         animation: viewModel,
         builder: (context, _) {
-          // 회원 정보 가져오기
           final memberInfo = viewModel.memberInfo;
 
           return SingleChildScrollView(
@@ -72,8 +129,29 @@ class _MyPageScreenState extends State<MyPageScreen> {
                     ),
                   ),
                   const SizedBox(height: 12),
+                  // 프로필 사진 수정 버튼
                   GestureDetector(
-                    onTap: () => viewModel.pickImage(context),
+                    onTap: () async {
+                      // 1. 이미지 선택
+                      await viewModel.pickImage(context);
+
+                      // 2. 이미지가 성공적으로 선택되었다면 프로필 수정 API 호출
+                      if (viewModel.coverImage != null) {
+                        final success = await viewModel.updateProfile(
+                          newCoverImage: viewModel.coverImage,
+                          // 프로필 사진 수정 시에도 기존 닉네임을 request에 전달해야 함
+                          newNickname: viewModel.memberInfo?.nickname,
+                        );
+
+                        if (success) {
+                          // 성공 피드백
+                          if (mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('프로필 사진이 성공적으로 수정되었습니다.')));
+                        } else {
+                          // 실패 피드백
+                          if (mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('프로필 사진 수정에 실패했습니다.')));
+                        }
+                      }
+                    },
                     child: Text(
                       '프로필 사진 수정',
                       style: AppFont.size14.copyWith(
@@ -100,10 +178,11 @@ class _MyPageScreenState extends State<MyPageScreen> {
                       Padding(
                         padding: const EdgeInsets.only(left: 30, right: 20),
                         child: HorizontalLabeledTextField(
-                            title: '닉네임',
-                            // 조회된 닉네임 적용
-                            hintText: memberInfo?.nickname ?? '닉네임을 불러오는 중...',
-                            showEditIcon: true
+                          title: '닉네임',
+                          hintText: memberInfo?.nickname ?? '닉네임을 불러오는 중...',
+                          showEditIcon: true,
+                          // 닉네임 수정 아이콘 탭 이벤트 연결
+                          onEditTap: () => _editNickname(context),
                         ),
                       ),
                       const SizedBox(height: 20),

--- a/lib/presentation/screens/my_page/my_page_view_model.dart
+++ b/lib/presentation/screens/my_page/my_page_view_model.dart
@@ -1,18 +1,29 @@
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
+import 'package:cherrypic/data/member/dto/response/member_info_dto.dart';
+
+import '../../../data/member/repositories/member_repository.dart';
+
 
 enum LoginType { kakao, apple }
 
 class MyPageViewModel extends ChangeNotifier {
-  /// 선택된 이미지 데이터
+
+  final MemberRepository _memberRepository;
+
+  MyPageViewModel({MemberRepository? memberRepository})
+      : _memberRepository = memberRepository ?? MemberRepository();
+
+  MemberInfoDto? _memberInfo;
+  MemberInfoDto? get memberInfo => _memberInfo;
+
   Uint8List? _coverImage;
-  /// View에서 데이터를 사용할 수 있도록 Getter 제공
   Uint8List? get coverImage => _coverImage;
-  /// 로그인 타입 초기화
+
   LoginType loginType = LoginType.kakao;
 
-  /// 갤러리에서 이미지를 선택하는 메소드
+  /// 갤러리에서 이미지를 선택
   Future<void> pickImage(BuildContext context) async {
     final List<AssetEntity>? assets = await AssetPicker.pickAssets(
       context,
@@ -22,7 +33,6 @@ class MyPageViewModel extends ChangeNotifier {
       ),
     );
 
-    /// 사용자가 이미지를 선택하고 확인을 눌렀을 경우
     if (assets != null && assets.isNotEmpty) {
       final AssetEntity selectedAsset = assets.first;
       final Uint8List? imageData = await selectedAsset.thumbnailDataWithSize(
@@ -32,6 +42,23 @@ class MyPageViewModel extends ChangeNotifier {
       _coverImage = imageData;
       notifyListeners();
     }
+  }
+
+  /// 멤버 정보 불러오기
+  Future<void> fetchMemberInfo() async {
+    try {
+      _memberInfo = await _memberRepository.getMemberInfo();
+
+      if (_memberInfo?.oauthProvider.toLowerCase() == 'apple') {
+        loginType = LoginType.apple;
+      } else {
+        loginType = LoginType.kakao;
+      }
+    } catch (e) {
+      debugPrint('Error fetching member info: $e');
+      _memberInfo = null;
+    }
+    notifyListeners();
   }
 
   /// 로그인 Type 라벨

--- a/lib/presentation/screens/my_page/my_page_view_model.dart
+++ b/lib/presentation/screens/my_page/my_page_view_model.dart
@@ -3,15 +3,21 @@ import 'package:flutter/material.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 import 'package:cherrypic/data/member/dto/response/member_info_dto.dart';
 import 'package:cherrypic/data/member/dto/request/member_edit_profile_request_dto.dart';
-import '../../../data/member/repositories/member_repository.dart'; // 추가
+import '../../../data/member/repositories/member_repository.dart';
+import '../../../data/member/services/profile_image_upload_service.dart'; // 추가
 
 enum LoginType { kakao, apple }
 
 class MyPageViewModel extends ChangeNotifier {
   final MemberRepository _memberRepository;
+  final ProfileImageUploadService _uploadService;
 
-  MyPageViewModel({MemberRepository? memberRepository})
-      : _memberRepository = memberRepository ?? MemberRepository();
+  MyPageViewModel({
+    MemberRepository? memberRepository,
+
+    ProfileImageUploadService? uploadService,
+  })  : _memberRepository = memberRepository ?? MemberRepository(),
+        _uploadService = uploadService ?? ProfileImageUploadService(); // 기본 인스턴스 생성
 
   MemberInfoDto? _memberInfo;
   MemberInfoDto? get memberInfo => _memberInfo;
@@ -21,8 +27,7 @@ class MyPageViewModel extends ChangeNotifier {
 
   LoginType loginType = LoginType.kakao;
 
-  /// 갤러리에서 이미지를 선택
-  Future<void> pickImage(BuildContext context) async {
+  Future<void> pickAndSetProfileImage(BuildContext context) async {
     final List<AssetEntity>? assets = await AssetPicker.pickAssets(
       context,
       pickerConfig: const AssetPickerConfig(
@@ -37,7 +42,6 @@ class MyPageViewModel extends ChangeNotifier {
         const ThumbnailSize(500, 500),
       );
 
-      /// 미리보기
       _coverImage = imageData;
       notifyListeners();
 
@@ -56,7 +60,7 @@ class MyPageViewModel extends ChangeNotifier {
     }
   }
 
-  /// 멤버 정보 불러오기
+  /// 멤버 정보 불러오기 (로직 유지)
   Future<void> fetchMemberInfo() async {
     try {
       _memberInfo = await _memberRepository.getMemberInfo();
@@ -73,15 +77,17 @@ class MyPageViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-
-  /// TODO: 이 함수를 실제 이미지 업로드 로직으로 교체해야 합니다.
+  /// 프로필 이미지 수정
   Future<String?> _uploadCoverImage(Uint8List imageData) async {
-    debugPrint('Uploading image... (Placeholder)');
-    // 실제 이미지 업로드 로직 후 반환된 URL이라고 가정
-    return 'https://new-profile-image.com/uploaded-pic-${DateTime.now().millisecondsSinceEpoch}.jpg';
+    try {
+      return await _uploadService.uploadCoverImage(imageData);
+    } catch (e) {
+      debugPrint('Error uploading profile image: $e');
+      return null;
+    }
   }
 
-  /// 프로필 수정 (닉네임 또는 이미지 URL)
+  /// 프로필 수정
   Future<bool> updateProfile({
     String? newNickname,
     Uint8List? newCoverImage,
@@ -97,19 +103,16 @@ class MyPageViewModel extends ChangeNotifier {
     nicknameToSend = newNickname ?? _memberInfo!.nickname;
 
     if (newCoverImage != null) {
-      // 1. 이미지를 업로드하고 URL을 받습니다.
       profileImageUrlToSend = await _uploadCoverImage(newCoverImage);
       if (profileImageUrlToSend == null) {
         debugPrint('Image upload failed. Profile update aborted.');
         return false;
       }
     } else {
-      // 이미지 변경이 없다면 기존 URL을 사용합니다.
       profileImageUrlToSend = _memberInfo!.profileImageUrl;
     }
 
     try {
-      // 2. 받은 URL을 포함하여 프로필 정보를 업데이트합니다.
       final requestDto = MemberEditProfileRequestDto(
         nickname: nicknameToSend,
         profileImageUrl: profileImageUrlToSend,
@@ -117,9 +120,8 @@ class MyPageViewModel extends ChangeNotifier {
 
       await _memberRepository.updateProfile(requestDto);
 
-      // 3. 수정 성공 후 최신 정보를 다시 불러와 화면을 갱신합니다.
       await fetchMemberInfo();
-      _coverImage = null; // 미리 보기 이미지는 성공적으로 서버에 반영되었으므로 초기화
+      _coverImage = null;
 
       debugPrint('Profile update successful! New Nickname: $nicknameToSend');
       return true;

--- a/lib/presentation/screens/my_page/my_page_view_model.dart
+++ b/lib/presentation/screens/my_page/my_page_view_model.dart
@@ -2,14 +2,12 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 import 'package:cherrypic/data/member/dto/response/member_info_dto.dart';
-
-import '../../../data/member/repositories/member_repository.dart';
-
+import 'package:cherrypic/data/member/dto/request/member_edit_profile_request_dto.dart';
+import '../../../data/member/repositories/member_repository.dart'; // 추가
 
 enum LoginType { kakao, apple }
 
 class MyPageViewModel extends ChangeNotifier {
-
   final MemberRepository _memberRepository;
 
   MyPageViewModel({MemberRepository? memberRepository})
@@ -39,8 +37,22 @@ class MyPageViewModel extends ChangeNotifier {
         const ThumbnailSize(500, 500),
       );
 
+      /// 미리보기
       _coverImage = imageData;
       notifyListeners();
+
+      if (_coverImage != null) {
+        final success = await updateProfile(
+          newCoverImage: _coverImage,
+          newNickname: memberInfo?.nickname,
+        );
+
+        if (!success) {
+          debugPrint('프로필 이미지 수정 실패');
+        } else {
+          debugPrint('프로필 이미지 수정 성공');
+        }
+      }
     }
   }
 
@@ -59,6 +71,64 @@ class MyPageViewModel extends ChangeNotifier {
       _memberInfo = null;
     }
     notifyListeners();
+  }
+
+
+  /// TODO: 이 함수를 실제 이미지 업로드 로직으로 교체해야 합니다.
+  Future<String?> _uploadCoverImage(Uint8List imageData) async {
+    debugPrint('Uploading image... (Placeholder)');
+    // 실제 이미지 업로드 로직 후 반환된 URL이라고 가정
+    return 'https://new-profile-image.com/uploaded-pic-${DateTime.now().millisecondsSinceEpoch}.jpg';
+  }
+
+  /// 프로필 수정 (닉네임 또는 이미지 URL)
+  Future<bool> updateProfile({
+    String? newNickname,
+    Uint8List? newCoverImage,
+  }) async {
+    if (_memberInfo == null) {
+      debugPrint('Error: Member info is not loaded.');
+      return false;
+    }
+
+    String nicknameToSend;
+    String? profileImageUrlToSend;
+
+    nicknameToSend = newNickname ?? _memberInfo!.nickname;
+
+    if (newCoverImage != null) {
+      // 1. 이미지를 업로드하고 URL을 받습니다.
+      profileImageUrlToSend = await _uploadCoverImage(newCoverImage);
+      if (profileImageUrlToSend == null) {
+        debugPrint('Image upload failed. Profile update aborted.');
+        return false;
+      }
+    } else {
+      // 이미지 변경이 없다면 기존 URL을 사용합니다.
+      profileImageUrlToSend = _memberInfo!.profileImageUrl;
+    }
+
+    try {
+      // 2. 받은 URL을 포함하여 프로필 정보를 업데이트합니다.
+      final requestDto = MemberEditProfileRequestDto(
+        nickname: nicknameToSend,
+        profileImageUrl: profileImageUrlToSend,
+      );
+
+      await _memberRepository.updateProfile(requestDto);
+
+      // 3. 수정 성공 후 최신 정보를 다시 불러와 화면을 갱신합니다.
+      await fetchMemberInfo();
+      _coverImage = null; // 미리 보기 이미지는 성공적으로 서버에 반영되었으므로 초기화
+
+      debugPrint('Profile update successful! New Nickname: $nicknameToSend');
+      return true;
+    } catch (e) {
+      debugPrint('Error updating profile: $e');
+      return false;
+    } finally {
+      notifyListeners();
+    }
   }
 
   /// 로그인 Type 라벨


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #43 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 회원 정보 조회 api를 추가했습니다.
-  프로필 이름 및 이미지 수정하기 api를 추가했습니다.
- 앨범 결제정보 페이지는 앨범 목록 조회 api 사용해서 type => pro or premium 구분으로 지정을 해놓았습니다.
- 앨범 결제내역 조회 api를 추가했습니다.
- 앨범 결제내역 페이지의 상단 paymentBox는 앨범 결제 정보 목록을 띄울때 앨범 목록 조회 api를 전달해서 사용했고, 구독 정보 조회 api를 합쳐서 띄우도록 했습니다.
- 앨범 관리 페이지는 앨범 결제 내역 조회 했던것과 동일한 방식으로 진행했습니다. status에 따라 active의 경우는 이용중, expired의 경우는 결제 대기로 구분시켰습니다.

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 마이페이지/설정/알람 토글 2개 api는 추가할 예정이라고 해서 제외시켰고, 로컬사진 삭제 api는 추가할 예정입니다.
- 실물사진 및 배송지 관리의 경우, 추후 서비스여서 api가 없고, 연결할 필요가 없어서 제외시켰습니다.
- 앨범 가입 이력 관련 api는 추가할 예정이라고 해서 제외시켰습니다.
- Pro/Premium 앨범의 경우, 실제로 결제를 해야지 paymentId를 얻을 수 있어서, 이 경우의 test는 하지 못했습니다.
- 로그아웃 api 추가할 예정입니다.
- 회원탈퇴 api는 아직 없어서 구현 못했습니다.